### PR TITLE
feat: Master Loot multi-user sync via SendAddonMessage

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -58,7 +58,10 @@ function addon:PLAYER_LOGIN()
     self:RegisterEvent("LOOT_CLOSED")
     self:RegisterEvent("CHAT_MSG_SYSTEM")
 
-    -- Addon message event (for Master Loot sync)
+    -- Addon message event (for Master Loot sync).
+    -- NOTE: RegisterAddonMessagePrefix does NOT exist in WoW 3.3.5 — it was
+    -- added in patch 4.1.0. In 3.3.5, CHAT_MSG_ADDON fires unconditionally
+    -- for all addon messages with no prefix registration needed.
     self:RegisterEvent("CHAT_MSG_ADDON")
 
     -- Class cache: refresh when raid/party composition changes
@@ -209,7 +212,14 @@ function addon:CHAT_MSG_SYSTEM(event, message)
 end
 
 function addon:CHAT_MSG_ADDON(event, prefix, message, distribution, sender)
-    -- Only process messages for Looty (prefix = "LOOTY")
+    -- Debug: log ALL addon messages so we can confirm the event fires at all
+    if self.db and self.db.debug then
+        DEFAULT_CHAT_FRAME:AddMessage(string.format(
+            "|cff00ff00[LOOTY ADDON]|r prefix=%s dist=%s sender=%s msg=%.40s",
+            tostring(prefix), tostring(distribution),
+            tostring(sender), tostring(message)))
+    end
+
     if prefix ~= "LOOTY" then return end
     if LootyMasterLoot then
         LootyMasterLoot:OnAddonMessage(prefix, message, distribution, sender)
@@ -220,6 +230,15 @@ function addon:GROUP_ROSTER_UPDATE(event)
     -- Refresh class cache when raid/party composition changes
     if LootyUI.RefreshClassCache then
         LootyUI:RefreshClassCache()
+    end
+    -- Re-resolve ML role: roster may not be populated during PLAYER_LOGIN,
+    -- so a player logging in while already in a ML group will get the correct
+    -- role here once the roster is ready.
+    if LootyMasterLoot then
+        LootyMasterLoot:ResolveRole()
+        if LootyUI and LootyUI.Refresh then
+            LootyUI:Refresh()
+        end
     end
 end
 

--- a/Core.lua
+++ b/Core.lua
@@ -58,6 +58,11 @@ function addon:PLAYER_LOGIN()
     self:RegisterEvent("LOOT_CLOSED")
     self:RegisterEvent("CHAT_MSG_SYSTEM")
 
+    -- Addon message event (for Master Loot sync)
+    self:RegisterEvent("CHAT_MSG_ADDON")
+
+    -- Class cache: refresh when raid/party composition changes
+
     -- Class cache: refresh when raid/party composition changes
     self:RegisterEvent("GROUP_ROSTER_UPDATE")
 
@@ -201,6 +206,14 @@ end
 function addon:CHAT_MSG_SYSTEM(event, message)
     -- Delegate to Parser for /roll message detection
     LootyParser:ProcessSystemMessage(message)
+end
+
+function addon:CHAT_MSG_ADDON(event, prefix, message, distribution, sender)
+    -- Only process messages for Looty (prefix = "LOOTY")
+    if prefix ~= "LOOTY" then return end
+    if LootyMasterLoot then
+        LootyMasterLoot:OnAddonMessage(prefix, message, distribution, sender)
+    end
 end
 
 function addon:GROUP_ROSTER_UPDATE(event)
@@ -347,6 +360,13 @@ SlashCmdList["LOOTY"] = function(msg)
         else
             addon:Print("Master Loot module not loaded.")
         end
+    elseif msg == "mtestremote" then
+        -- Inject remote test data (simulate receiving items from ML)
+        if LootyMasterLoot then
+            LootyMasterLoot:InjectRemoteTest()
+        else
+            addon:Print("Master Loot module not loaded.")
+        end
     elseif msg == "debug" then
         addon.db.debug = not addon.db.debug
         addon:Print("Debug " .. (addon.db.debug and "ON" or "OFF"))
@@ -357,6 +377,7 @@ SlashCmdList["LOOTY"] = function(msg)
         addon:Print("  /looty clear  - Clear completed roll history")
         addon:Print("  /looty test   - Inject mock Group Loot rolls")
         addon:Print("  /looty mtest  - Inject mock Master Loot data")
+        addon:Print("  /looty mtestremote - Inject mock remote ML data")
         addon:Print("  /looty debug  - Toggle data debug")
     end
 end

--- a/MasterLoot.lua
+++ b/MasterLoot.lua
@@ -8,40 +8,150 @@ local L = Looty_L
 local MasterLoot = {}
 LootyMasterLoot = MasterLoot
 
--- State
-MasterLoot.active = false       -- Is Master Loot mode active?
-MasterLoot.items = {}           -- Array of item entries
-MasterLoot.currentRoll = nil    -- Index of item currently rolling
-MasterLoot.rollTimer = nil      -- Frame for roll countdown
-MasterLoot.rollDuration = 30    -- Seconds for each roll
-MasterLoot.isML = false         -- Is current player the Master Looter?
+-- ---- State ----
 
--- Remote state (for non-ML clients receiving sync from ML)
-MasterLoot.remoteMode = false    -- Are we in remote spectator mode?
-MasterLoot.remoteItems = {}      -- Mirror of ML's items (indexed by index)
-MasterLoot.remoteML = nil        -- Name of ML we're tracking
+-- Loot method state (set independently of role)
+MasterLoot.lootMethod         = nil    -- Raw value from GetLootMethod(): "master"|"group"|etc.
+MasterLoot.isMasterLootActive = false  -- true when lootMethod == "master"
 
--- Throttle for sending messages (rate limit protection)
--- WoW 3.3.5 has rate limiting on SendAddonMessage - sending too many
--- messages too fast can disconnect the player. We use 0.5s between messages.
--- Items are queued and sent one by one with this delay.
-MasterLoot.msgThrottle = 0.5    -- Min seconds between auto-messages
-MasterLoot.lastMsgTime = 0      -- Timestamp of last message sent
-MasterLoot.pendingItems = {}     -- Queue for items waiting to be sent
-MasterLoot.sendTimer = nil       -- Timer frame for throttled sending
+-- Role of the current player within this loot session:
+--   "MasterLooter" → this player is the ML
+--   "Raider"       → loot is master but this player is not the ML
+--   nil            → not in master loot mode
+MasterLoot.role = nil
+
+-- Legacy aliases kept for backward compat with UI / external code.
+-- These are DERIVED from role/isMasterLootActive — never set directly.
+MasterLoot.active = false   -- true when isMasterLootActive
+MasterLoot.isML   = false   -- true when role == "MasterLooter"
+
+-- ML-side item list and roll tracking
+MasterLoot.items       = {}   -- Array of item entries (ML only)
+MasterLoot.currentRoll = nil  -- Index of item currently rolling
+MasterLoot.rollTimer   = nil  -- Frame for roll countdown
+MasterLoot.rollDuration = 30  -- Seconds for each roll
+
+-- Remote state (for Raider clients receiving sync from ML)
+MasterLoot.remoteMode  = false  -- true once role is "Raider" and ML mode is active
+MasterLoot.remoteItems = {}     -- Mirror of ML's items (indexed by item index)
+MasterLoot.remoteML    = nil    -- Name of the ML we are tracking
+
+-- Throttle for SendAddonMessage (WoW 3.3.5 rate-limit protection).
+-- Items are queued and sent one by one with a 0.5 s gap.
+MasterLoot.msgThrottle  = 0.5  -- Min seconds between auto-messages
+MasterLoot.lastMsgTime  = 0    -- Timestamp of last message sent
+MasterLoot.pendingItems = {}   -- Queue for messages waiting to be sent
+MasterLoot.sendTimer    = nil  -- Timer frame for throttled sending
 
 -- Message Protocol (prefix: "LOOTY")
--- ITEM|index|link|texture|quality|name  → One per item, 0.5s apart
--- ROLL_START|index                      → Roll started for item
--- ROLL_END|index|winnerName          → Roll ended, winner announced
--- ITEM_DONE|index                      → Item marked as done
--- CLEAR                               → All items cleared (ML mode off)
+-- Field separator: \001 (ASCII SOH) — cannot appear in item links or names.
+-- ITEM\001index\001link\001texture\001quality\001name  → One per item, 0.5 s apart
+-- ROLL_START\001index                                  → Roll started for item
+-- ROLL_END\001index\001winnerName                      → Roll ended, winner announced
+-- ITEM_DONE\001index                                   → Item marked as done
+-- CLEAR                                                → All items cleared (ML mode off)
 
--- ---- Message Sending (ML side) ----
+-- ============================================================
+-- ---- Internal helpers: loot method and ML detection ----
+-- ============================================================
+
+-- Returns the raw loot method string from the API.
+local function DetectLootMethod()
+    local method = GetLootMethod()
+    return method
+end
+
+-- Returns true if THIS player is the Master Looter.
+--
+-- Authoritative source: wowprogramming.com Wayback Machine, May 2010 (3.3.5 era)
+--   partyMaster == 0    → THIS player is ML (only reliable in party, or same subgroup in raid)
+--   partyMaster == nil  → ML is not in this player's party subgroup (common in raids)
+--   raidMaster  == N    → raid index of the ML in a raid group
+--
+-- Correct pattern (verified against epgp, a real 3.3.5 addon):
+--   In a raid:  resolve ML name via GetRaidRosterInfo(raidMaster), compare to UnitName("player")
+--   In a party: partyMaster == 0 means this player is ML
+--               partyMaster 1-4 means party member N is ML
+--
+-- DO NOT compare UnitInRaid("player") == raidMaster — UnitInRaid returns a 0-based
+-- index internally and its relationship to raidMaster is unreliable across subgroups.
+-- Name comparison is the only safe cross-context method.
+local function DetectIsML()
+    local method, partyMaster, raidMaster = GetLootMethod()
+    if method ~= "master" then return false end
+
+    local myName = UnitName("player")
+
+    if raidMaster then
+        -- Raid context: get the ML's actual name from the roster and compare
+        local mlName = GetRaidRosterInfo(raidMaster)
+        return mlName == myName
+    end
+
+    if partyMaster == 0 then
+        -- Party context: 0 unambiguously means this player is the ML
+        return true
+    end
+
+    return false
+end
+
+-- ============================================================
+-- ---- ResolveRole: single source of truth for role state ----
+-- ============================================================
+
+-- Call this whenever the loot method may have changed:
+--   Initialize(), OnLootMethodChanged(), OnLootOpened()
+--
+-- Sets: lootMethod, isMasterLootActive, role, active, isML, remoteMode
+function MasterLoot:ResolveRole()
+    local method = DetectLootMethod()
+    self.lootMethod         = method
+    self.isMasterLootActive = (method == "master")
+
+    -- Not in master loot mode at all — clear everything
+    if not self.isMasterLootActive then
+        self.role   = nil
+        self.active = false
+        self.isML   = false
+        -- remoteMode/remoteML are cleared by the caller (OnLootMethodChanged)
+        -- so that the CLEAR sync message can be sent first.
+        return
+    end
+
+    -- Master loot is active — now determine our role
+    self.active = true
+
+    if DetectIsML() then
+        self.role       = "MasterLooter"
+        self.isML       = true
+        self.remoteMode = false  -- ML never operates in remote mode
+    else
+        self.role       = "Raider"
+        self.isML       = false
+        self.remoteMode = true   -- Raider is always in receive mode when ML is active
+    end
+
+    if addon.db and addon.db.debug then
+        local _, partyID, raidID = GetLootMethod()
+        DEFAULT_CHAT_FRAME:AddMessage(string.format(
+            "|cff00ff00[LOOTY ML]|r ResolveRole: method=%s partyID=%s raidID=%s role=%s",
+            tostring(method), tostring(partyID), tostring(raidID), tostring(self.role)))
+    end
+end
+
+-- ============================================================
+-- ---- Message Sending (ML side only) ----
+-- ============================================================
 
 function MasterLoot:SendThrottledMessage(msg)
-    if not self.isML then return end
-    -- Add to queue
+    if not self.isML then
+        if addon.db and addon.db.debug then
+            DEFAULT_CHAT_FRAME:AddMessage(
+                "|cff00ff00[LOOTY ML]|r SendThrottledMessage SKIPPED — isML=false msg=" .. tostring(msg):sub(1, 40))
+        end
+        return
+    end
     table.insert(self.pendingItems, msg)
     self:ProcessSendQueue()
 end
@@ -49,10 +159,10 @@ end
 function MasterLoot:ProcessSendQueue()
     if #self.pendingItems == 0 then return end
     if GetTime() - self.lastMsgTime < self.msgThrottle then
-        -- Schedule timer to try again
+        -- Schedule a timer to retry
         if not self.sendTimer then
             self.sendTimer = CreateFrame("Frame")
-            self.sendTimer:SetScript("OnUpdate", function(self)
+            self.sendTimer:SetScript("OnUpdate", function()
                 MasterLoot:ProcessSendQueue()
             end)
         end
@@ -60,305 +170,266 @@ function MasterLoot:ProcessSendQueue()
         return
     end
 
-    -- Send next message
     local msg = table.remove(self.pendingItems, 1)
-    SendAddonMessage("LOOTY", msg, "RAID")
+    -- Use "RAID" when in a raid group, "PARTY" otherwise.
+    -- In WoW 3.3.5, "RAID" does NOT reliably fall back to "PARTY" on all
+    -- server implementations, so we must pick the correct channel explicitly.
+    -- IsInRaid() does not exist in 3.3.5 — use GetNumRaidMembers() instead.
+    local channel = (GetNumRaidMembers() > 0) and "RAID" or "PARTY"
+    if addon.db and addon.db.debug then
+        DEFAULT_CHAT_FRAME:AddMessage(string.format(
+            "|cff00ff00[LOOTY ML]|r SEND channel=%s msg=%.50s",
+            channel, msg))
+    end
+    SendAddonMessage("LOOTY", msg, channel)
     self.lastMsgTime = GetTime()
 
-    -- If more items, will be picked up on next OnUpdate
     if #self.pendingItems == 0 and self.sendTimer then
         self.sendTimer:Hide()
     end
 end
 
+-- Field separator: ASCII \001 (SOH).
+-- Cannot appear in item links, texture paths, quality digits, or item names.
+-- This avoids the pipe-escaping problem entirely — WoW item links contain many
+-- literal | characters (|c color codes, |H hyperlinks, |h display text, |r reset)
+-- that would collide with any pipe-based delimiter scheme.
+local SEP = "\001"
+
 function MasterLoot:SerializeItem(item, index)
-    -- Compact format: ITEM|index|link|texture|quality|name
-    -- Escape pipe characters in link (safety measure)
-    local link = string.gsub(item.link or "", "|", "||")
+    -- Format: ITEM\001index\001link\001texture\001quality\001name
+    -- No escaping needed — SEP (\001) never appears in any of these fields.
+    local link    = item.link or ""
     local texture = item.texture or ""
     local quality = tostring(item.quality or 2)
-    local name = item.name or "Unknown"
-
-    return string.format("ITEM|%d|%s|%s|%s|%s",
-        index, link, texture, quality, name)
+    local name    = item.name or "Unknown"
+    return "ITEM" .. SEP .. index .. SEP .. link .. SEP .. texture .. SEP .. quality .. SEP .. name
 end
 
--- ---- Helper: check if player is Master Looter ----
+-- ============================================================
+-- ---- Lifecycle ----
+-- ============================================================
 
-local function CheckIsML()
-    local method, masterlooterPartyID, masterlooterRaidID = GetLootMethod()
-    if method ~= "master" then
-        MasterLoot.isML = false
-        return false
-    end
-
-    -- In WOTLK 3.3.5, GetLootMethod() returns NUMBERS for ML identity,
-    -- NOT names:
-    --   masterlooterPartyID = 0 means THIS PLAYER is ML
-    --   masterlooterPartyID = 1-4 means party member 1-4 is ML
-    --   masterlooterRaidID = raid index or nil
-    -- TODO: Check for current player raidID and compare with masterlooterPartyID: see https://web.archive.org/web/20100513002458/http://wowprogramming.com/docs/api/GetLootMethod
-    if masterlooterPartyID == 0 then
-        MasterLoot.isML = true
-        return true
-    end
-
-    -- In a raid, check if raid index matches our own
-    if masterlooterRaidID and UnitIsRaidMember("player") then
-        for i = 1, GetNumGroupMembers() do
-            if UnitName("raid" .. i) == UnitName("player") then
-                MasterLoot.isML = (masterlooterRaidID == i)
-                return MasterLoot.isML
-            end
-        end
-    end
-
-    -- Fallback: party member is ML (not us)
-    MasterLoot.isML = false
-    return false
-end
-
--- ---- Initialize: called on PLAYER_LOGIN to set initial state ----
-
+-- Called on PLAYER_LOGIN to set initial state.
 function MasterLoot:Initialize()
-    -- Check if we're already in Master Loot mode at login
-    -- (PARTY_LOOT_METHOD_CHANGED may not have fired since login)
-    local method, partyID, raidID = GetLootMethod()
-    if method == "master" then
-        MasterLoot.active = true
-        CheckIsML()
-        if addon.db and addon.db.debug then
-            DEFAULT_CHAT_FRAME:AddMessage(string.format(
-                "|cff00ff00[LOOTY ML]|r ML at login: method=%s partyID=%s raidID=%s isML=%s",
-                tostring(method), tostring(partyID), tostring(raidID), tostring(MasterLoot.isML)))
-        end
-    else
-        MasterLoot.active = false
-        MasterLoot.isML = false
-        if addon.db and addon.db.debug then
-            DEFAULT_CHAT_FRAME:AddMessage(string.format(
-                "|cff00ff00[LOOTY ML]|r Not ML at login: method=%s partyID=%s raidID=%s",
-                tostring(method), tostring(partyID), tostring(raidID)))
-        end
+    self:ResolveRole()
+
+    if addon.db and addon.db.debug then
+        DEFAULT_CHAT_FRAME:AddMessage(string.format(
+            "|cff00ff00[LOOTY ML]|r Initialize complete: role=%s active=%s isML=%s remoteMode=%s",
+            tostring(self.role), tostring(self.active),
+            tostring(self.isML), tostring(self.remoteMode)))
     end
 end
 
+-- ============================================================
 -- ---- Event: PARTY_LOOT_METHOD_CHANGED ----
+-- ============================================================
 
 function MasterLoot:OnLootMethodChanged()
-    local method, partyID, raidID = GetLootMethod()
-    local wasActive = MasterLoot.active
+    local wasActive = self.active
 
-    if method == "master" then
-        MasterLoot.active = true
-        CheckIsML()
-        if addon.db and addon.db.debug then
-            DEFAULT_CHAT_FRAME:AddMessage(string.format(
-                "|cff00ff00[LOOTY ML]|r Master Loot activated: method=%s partyID=%s raidID=%s isML=%s",
-                tostring(method), tostring(partyID), tostring(raidID), tostring(MasterLoot.isML)))
-        end
-    else
-        MasterLoot.active = false
-        MasterLoot.items = {}
-        MasterLoot.currentRoll = nil
-        MasterLoot.rollTimer = nil
+    -- Send CLEAR before wiping state so the ML flag is still true during send
+    local wasML = self.isML
+    local newMethod = DetectLootMethod()
 
-        -- Sync: notify raid members that ML mode is off (ML only)
-        if MasterLoot.isML then
-            MasterLoot:SendThrottledMessage("CLEAR")
+    if newMethod ~= "master" then
+        -- Notify raid that ML mode is off (ML only, while isML is still true)
+        if wasML then
+            self:SendThrottledMessage("CLEAR")
         end
 
-        -- Clear remote state if we were in remote mode (non-ML clients)
-        if MasterLoot.remoteMode then
-            MasterLoot.remoteItems = {}
-            MasterLoot.remoteMode = false
-            MasterLoot.remoteML = nil
-        end
-
-        if addon.db and addon.db.debug then
-            DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00[LOOTY ML]|r Master Loot mode deactivated.")
-        end
+        -- Clear all state
+        self.items       = {}
+        self.currentRoll = nil
+        self.rollTimer   = nil
+        self.remoteItems = {}
+        self.remoteMode  = false
+        self.remoteML    = nil
     end
 
-    if wasActive ~= MasterLoot.active then
-        -- Switch to Master tab when mode changes
+    -- Now resolve the new role (also clears active/isML if not master)
+    self:ResolveRole()
+
+    -- Switch tabs on mode change
+    if wasActive ~= self.active then
         if LootyUI and LootyUI.SwitchTab then
-            if MasterLoot.active then
+            if self.active then
                 LootyUI:SwitchTab("master")
             elseif LootyUI.currentTab == "master" then
                 LootyUI:SwitchTab("grouplot")
             end
         end
+    end
+
     if LootyUI and LootyUI.Refresh then
         LootyUI:Refresh()
     end
 end
 
--- ---- Message Receiving (All clients) ----
+-- ============================================================
+-- ---- Message Receiving (Raider side) ----
+-- ============================================================
 
 function MasterLoot:DeserializeItem(message)
-    -- Parse: ITEM|index|link|texture|quality|name
-    -- Link may contain escaped pipes (||), need to handle carefully
-    local header, rest = string.match(message, "^ITEM|(.+)$")
-    if not header then return nil end
+    -- Format: ITEM\001index\001link\001texture\001quality\001name
+    -- SEP is \001 — split cleanly with no pipe-escaping complications.
+    if not string.find(message, "^ITEM" .. SEP) then return nil end
 
-    -- Split by | but respect escaped ||
     local parts = {}
-    local current = ""
-    local i = 1
-    while i <= #rest do
-        local char = string.sub(rest, i, i)
-        if char == "|" and i < #rest and string.sub(rest, i+1, i+1) == "|" then
-            current = current .. "|"
-            i = i + 2
-        elseif char == "|" then
-            table.insert(parts, current)
-            current = ""
-            i = i + 1
-        else
-            current = current .. char
-            i = i + 1
-        end
+    -- strsplit does not exist in all Lua environments; use gmatch with SEP
+    -- Note: string.gmatch pattern-escaping — \001 has no special meaning in
+    -- Lua patterns so it can be used directly as a literal character.
+    for segment in string.gmatch(message, "[^" .. SEP .. "]+") do
+        table.insert(parts, segment)
     end
-    table.insert(parts, current)  -- Last part
+    -- parts[1] = "ITEM", parts[2] = index, parts[3] = link, parts[4] = texture,
+    -- parts[5] = quality, parts[6] = name
+    if #parts < 6 then return nil end
 
-    if #parts < 5 then return nil end
-
+    local idx = tonumber(parts[2])
     return {
-        index = tonumber(parts[1]),
-        link = string.gsub(parts[2], "||", "|"),  -- Unescape
-        texture = parts[3],
-        quality = tonumber(parts[4]) or 2,
-        name = parts[5],
-        -- Initialize other fields
-        slot = tonumber(parts[1]) or 0,
-        quantity = 1,
-        rolls = {},
-        rerolls = {},
-        rolling = false,
+        index     = idx,
+        link      = parts[3],
+        texture   = parts[4],
+        quality   = tonumber(parts[5]) or 2,
+        name      = parts[6],
+        slot      = idx or 0,
+        quantity  = 1,
+        rolls     = {},
+        rerolls   = {},
+        rolling   = false,
         rollStart = nil,
-        isDone = false,
-        winner = nil,
+        isDone    = false,
+        winner    = nil,
     }
 end
 
 function MasterLoot:OnAddonMessage(prefix, message, distribution, sender)
-    -- Only process messages for Looty
     if prefix ~= "LOOTY" then return end
-    -- ML doesn't process own messages
+    -- ML ignores its own broadcast messages
     if self.isML then return end
 
-    -- Set remote mode on first ITEM received
-    if not self.remoteMode and string.find(message, "^ITEM|") then
-        self.remoteMode = true
+    -- When we receive the first ITEM sync, record who the ML is
+    local itemPrefix = "ITEM" .. SEP
+    if string.sub(message, 1, #itemPrefix) == itemPrefix and not self.remoteML then
         self.remoteML = sender
         if addon.db and addon.db.debug then
-            DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00[LOOTY ML]|r Remote mode activated, ML: " .. sender)
+            DEFAULT_CHAT_FRAME:AddMessage(
+                "|cff00ff00[LOOTY ML]|r Raider: first ITEM received, ML is " .. sender)
         end
     end
 
-    -- Parse commands
-    if string.find(message, "^ITEM|") then
+    -- Dispatch by message type
+    if string.sub(message, 1, #itemPrefix) == itemPrefix then
         local item = self:DeserializeItem(message)
         if item then
             self.remoteItems[item.index] = item
             if addon.db and addon.db.debug then
-                DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00[LOOTY ML]|r Received item: " .. item.name)
+                DEFAULT_CHAT_FRAME:AddMessage(
+                    "|cff00ff00[LOOTY ML]|r Raider: received item " .. item.name)
             end
         end
-    elseif string.find(message, "^ROLL_START|") then
-        local _, _, idx = string.find(message, "ROLL_START|(%d+)")
-        idx = tonumber(idx)
+
+    elseif string.sub(message, 1, 11) == "ROLL_START" .. SEP then
+        local idx = tonumber(string.sub(message, 12))
         if idx and self.remoteItems[idx] then
-            self.remoteItems[idx].rolling = true
+            self.remoteItems[idx].rolling   = true
             self.remoteItems[idx].rollStart = GetTime()
-            self.remoteItems[idx].rolls = {}
-            self.remoteItems[idx].rerolls = {}
+            self.remoteItems[idx].rolls     = {}
+            self.remoteItems[idx].rerolls   = {}
         end
-    elseif string.find(message, "^ROLL_END|") then
-        local _, _, idx, winner = string.find(message, "ROLL_END|(%d+)|(.+)")
-        idx = tonumber(idx)
+
+    elseif string.sub(message, 1, 9) == "ROLL_END" .. SEP then
+        local rest   = string.sub(message, 10)
+        local sepPos = string.find(rest, SEP, 1, true)
+        local idx, winner
+        if sepPos then
+            idx    = tonumber(string.sub(rest, 1, sepPos - 1))
+            winner = string.sub(rest, sepPos + 1)
+        else
+            idx = tonumber(rest)
+        end
         if idx and self.remoteItems[idx] then
-            self.remoteItems[idx].rolling = false
+            self.remoteItems[idx].rolling   = false
             self.remoteItems[idx].rollStart = nil
-            self.remoteItems[idx].winner = winner ~= "none" and winner or nil
+            self.remoteItems[idx].winner    = (winner and winner ~= "none") and winner or nil
         end
-    elseif string.find(message, "^ITEM_DONE|") then
-        local _, _, idx = string.find(message, "ITEM_DONE|(%d+)")
-        idx = tonumber(idx)
+
+    elseif string.sub(message, 1, 10) == "ITEM_DONE" .. SEP then
+        local idx = tonumber(string.sub(message, 11))
         if idx and self.remoteItems[idx] then
             self.remoteItems[idx].isDone = true
         end
+
     elseif message == "CLEAR" then
         self.remoteItems = {}
-        self.remoteMode = false
-        self.remoteML = nil
+        self.remoteMode  = false
+        self.remoteML    = nil
     end
 
-    -- Refresh UI
     if LootyUI and LootyUI.Refresh then
         LootyUI:Refresh()
     end
 end
-end
 
+-- ============================================================
 -- ---- Event: LOOT_OPENED ----
+-- ============================================================
 
 function MasterLoot:OnLootOpened()
-    if not MasterLoot.active then return end
+    -- Re-verify role every time loot opens; PARTY_LOOT_METHOD_CHANGED may
+    -- not have fired since login (e.g. player joined a group already in ML).
+    self:ResolveRole()
 
-    -- Re-verify ML status every time loot opens (it can change between sessions
-    -- and PARTY_LOOT_METHOD_CHANGED may not have fired since login).
-    CheckIsML()
+    if not self.active then return end
 
-    -- Debug: log current ML state
     if addon.db and addon.db.debug then
         local method, partyID, raidID = GetLootMethod()
         DEFAULT_CHAT_FRAME:AddMessage(string.format(
-            "|cff00ff00[LOOTY ML]|r OnLootOpened: method=%s partyID=%s raidID=%s isML=%s items=%d",
-            tostring(method), tostring(partyID), tostring(raidID), tostring(MasterLoot.isML), #MasterLoot.items))
+            "|cff00ff00[LOOTY ML]|r OnLootOpened: method=%s partyID=%s raidID=%s role=%s items=%d",
+            tostring(method), tostring(partyID), tostring(raidID),
+            tostring(self.role), #self.items))
     end
 
-    -- Read items from the loot window
+    -- Only the ML reads and broadcasts the loot window
+    if not self.isML then return end
+
     local numItems = GetNumLootItems()
     if numItems == 0 then return end
 
-    MasterLoot.items = {}
+    self.items = {}
     for i = 1, numItems do
-        local texture, name, quantity, quality, locked, isQuestItem, questId, isActive = GetLootSlotInfo(i)
-
-        -- WOTLK 3.3.5 does NOT have GetLootSlotType (added in 5.0.4/1.13.2).
-        -- Filter out money/coin slots: they return a coin string as name and
-        -- have no item link. Real items always return a valid link.
+        local texture, name, quantity, quality = GetLootSlotInfo(i)
+        -- WOTLK 3.3.5 has no GetLootSlotType; filter money by absence of link
         local link = GetLootSlotLink(i)
         if name and link then
-            table.insert(MasterLoot.items, {
-                slot = i,
-                name = name,
-                link = link,
-                texture = texture,
-                quantity = quantity or 1,
-                quality = quality or 2,
-                rolls = {},
-                rerolls = {},
-                rolling = false,
+            table.insert(self.items, {
+                slot      = i,
+                name      = name,
+                link      = link,
+                texture   = texture,
+                quantity  = quantity or 1,
+                quality   = quality or 2,
+                rolls     = {},
+                rerolls   = {},
+                rolling   = false,
                 rollStart = nil,
-                isDone = false,
-                winner = nil,
+                isDone    = false,
+                winner    = nil,
             })
         end
     end
 
-    -- Send items to raid members (one per message, 0.5s throttle)
-    if self.isML then
-        for index, item in ipairs(MasterLoot.items) do
-            local msg = self:SerializeItem(item, index)
-            self:SendThrottledMessage(msg)
-        end
+    -- Broadcast items to Raiders (throttled, 0.5 s apart)
+    for index, item in ipairs(self.items) do
+        local msg = self:SerializeItem(item, index)
+        self:SendThrottledMessage(msg)
     end
 
     if addon.db and addon.db.debug then
-        DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00[LOOTY ML]|r Loot opened: " .. #MasterLoot.items .. " items found.")
+        DEFAULT_CHAT_FRAME:AddMessage(
+            "|cff00ff00[LOOTY ML]|r Loot opened: " .. #self.items .. " items broadcast.")
     end
 
     if LootyUI and LootyUI.Refresh then
@@ -366,75 +437,88 @@ function MasterLoot:OnLootOpened()
     end
 end
 
+-- ============================================================
 -- ---- Event: LOOT_CLOSED ----
+-- ============================================================
 
 function MasterLoot:OnLootClosed()
-    -- Keep items in MasterLoot.items so rolls can continue after looting
-    -- They stay until ML clears them or switches loot method
+    -- Items stay alive so rolls can continue after the loot window closes.
+    -- They are cleared only when the ML switches loot method or calls ClearDone.
 end
 
--- ---- Start Roll ----
+-- ============================================================
+-- ---- Roll management (ML side) ----
+-- ============================================================
 
 function MasterLoot:StartRoll(itemIndex)
-    local item = MasterLoot.items[itemIndex]
+    local item = self.items[itemIndex]
     if not item or item.isDone or item.rolling then return end
 
-    -- Cancel any previous roll
-    if MasterLoot.rollTimer then
-        MasterLoot.rollTimer:Hide()
+    -- Cancel any previous active roll
+    if self.rollTimer then
+        self.rollTimer:Hide()
     end
 
-    item.rolling = true
+    item.rolling  = true
     item.rollStart = GetTime()
-    item.rolls = {}
-    item.rerolls = {}
-    item.winner = nil
-    MasterLoot.currentRoll = itemIndex
+    item.rolls    = {}
+    item.rerolls  = {}
+    item.winner   = nil
+    self.currentRoll = itemIndex
 
-    -- Announce to raid
-    local msg = ">> Rolling for: " .. (item.link or item.name) .. " — /roll now! (" .. MasterLoot.rollDuration .. "s)"
+    local msg = ">> Rolling for: " .. (item.link or item.name) ..
+                " — /roll now! (" .. self.rollDuration .. "s)"
     SendChatMessage(msg, "RAID_WARNING")
     addon:Print(msg)
 
-    -- Sync: notify raid members (ML only)
-    if MasterLoot.isML then
-        MasterLoot:SendThrottledMessage("ROLL_START|" .. itemIndex)
-    end
-
-    -- Start countdown timer
-    MasterLoot.rollTimer = MasterLoot:CreateTimer(itemIndex)
+        self:SendThrottledMessage("ROLL_START" .. SEP .. itemIndex)
+    self.rollTimer = self:CreateTimer(itemIndex)
 
     if LootyUI and LootyUI.Refresh then
         LootyUI:Refresh()
     end
 end
 
--- ---- End Roll (manual) ----
-
 function MasterLoot:EndRoll(itemIndex)
-    local item = MasterLoot.items[itemIndex]
+    local item = self.items[itemIndex]
     if not item or not item.rolling then return end
 
-    item.rolling = false
+    item.rolling  = false
     item.rollStart = nil
-    MasterLoot.currentRoll = nil
-    MasterLoot.rollTimer = nil
+    self.currentRoll = nil
+    self.rollTimer   = nil
 
-    -- Determine winner
-    local winner, winValue = MasterLoot:GetWinner(item)
+    local winner, winValue = self:GetWinner(item)
     item.winner = winner
 
     if winner then
-        local announceMsg = ">> " .. winner .. " wins " .. (item.link or item.name) .. " with " .. winValue .. "!"
+        local announceMsg = ">> " .. winner .. " wins " ..
+                            (item.link or item.name) .. " with " .. winValue .. "!"
         SendChatMessage(announceMsg, "RAID_WARNING")
         addon:Print(announceMsg)
     else
         addon:Print("No rolls for " .. (item.link or item.name))
     end
 
-    -- Sync: notify raid members (ML only)
-    if MasterLoot.isML then
-        MasterLoot:SendThrottledMessage("ROLL_END|" .. itemIndex .. "|" .. (winner or "none"))
+    self:SendThrottledMessage("ROLL_END" .. SEP .. itemIndex .. SEP .. (winner or "none"))
+
+    if LootyUI and LootyUI.Refresh then
+        LootyUI:Refresh()
+    end
+end
+
+function MasterLoot:CancelRoll()
+    if not self.currentRoll then return end
+    local item = self.items[self.currentRoll]
+    if not item then return end
+
+    item.rolling  = false
+    item.rollStart = nil
+    self.currentRoll = nil
+
+    if self.rollTimer then
+        self.rollTimer:Hide()
+        self.rollTimer = nil
     end
 
     if LootyUI and LootyUI.Refresh then
@@ -442,12 +526,14 @@ function MasterLoot:EndRoll(itemIndex)
     end
 end
 
+-- ============================================================
 -- ---- Timer ----
+-- ============================================================
 
 function MasterLoot:CreateTimer(itemIndex)
     local timer = CreateFrame("Frame")
     timer.itemIndex = itemIndex
-    timer.elapsed = 0
+    timer.elapsed   = 0
     timer:Show()
     timer:SetScript("OnUpdate", function(self, elapsed)
         self.elapsed = self.elapsed + elapsed
@@ -471,35 +557,34 @@ function MasterLoot:CreateTimer(itemIndex)
     return timer
 end
 
--- ---- Record Roll ----
+-- ============================================================
+-- ---- Roll recording (ML side, driven by Parser) ----
+-- ============================================================
 
 function MasterLoot:RecordRoll(playerName, value, itemName)
-    if not MasterLoot.active then return end
-    if not MasterLoot.currentRoll then return end
+    if not self.active then return end
+    if not self.currentRoll then return end
 
-    local item = MasterLoot.items[MasterLoot.currentRoll]
+    local item = self.items[self.currentRoll]
     if not item or not item.rolling then return end
 
-    -- Validate item name match (fuzzy — just check if item name is in the message)
-    if itemName and item.name and not (itemName:find(item.name, 1, true) or item.name:find(itemName, 1, true)) then
-        -- Don't reject outright — in Master Loot, /roll doesn't include item name
-        -- so we just associate with current roll
-    end
-
-    -- Check for duplicate (cheating detection)
+    -- Duplicate roll → cheating detection
     if item.rolls[playerName] then
         item.rerolls[playerName] = { value = value, time = GetTime() }
         if addon.db and addon.db.debug then
-            DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00[LOOTY ML]|r REROLL detected: " .. playerName .. " rolled " .. value .. " (first: " .. item.rolls[playerName].value .. ")")
+            DEFAULT_CHAT_FRAME:AddMessage(string.format(
+                "|cff00ff00[LOOTY ML]|r REROLL detected: %s rolled %d (first: %d)",
+                playerName, value, item.rolls[playerName].value))
         end
         return
     end
 
-    -- Record the roll
     item.rolls[playerName] = { value = value, time = GetTime() }
 
     if addon.db and addon.db.debug then
-        DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00[LOOTY ML]|r Roll recorded: " .. playerName .. " = " .. value .. " on " .. (item.name or "?"))
+        DEFAULT_CHAT_FRAME:AddMessage(string.format(
+            "|cff00ff00[LOOTY ML]|r Roll recorded: %s = %d on %s",
+            playerName, value, item.name or "?"))
     end
 
     if LootyUI and LootyUI.Refresh then
@@ -507,81 +592,55 @@ function MasterLoot:RecordRoll(playerName, value, itemName)
     end
 end
 
--- ---- Get Winner ----
+-- ============================================================
+-- ---- Winner resolution ----
+-- ============================================================
 
 function MasterLoot:GetWinner(item)
     local bestPlayer = nil
-    local bestValue = 0
-
+    local bestValue  = 0
     for playerName, rollInfo in pairs(item.rolls) do
         if rollInfo.value and rollInfo.value > bestValue then
-            bestValue = rollInfo.value
+            bestValue  = rollInfo.value
             bestPlayer = playerName
         end
     end
-
     return bestPlayer, bestValue
 end
 
--- ---- Clear Done Items ----
+-- ============================================================
+-- ---- Item state helpers ----
+-- ============================================================
+
+function MasterLoot:ToggleDone(itemIndex)
+    local item = self.items[itemIndex]
+    if not item then return end
+
+    item.isDone = not item.isDone
+    self:SendThrottledMessage("ITEM_DONE" .. SEP .. itemIndex)
+
+    if LootyUI and LootyUI.Refresh then
+        LootyUI:Refresh()
+    end
+end
 
 function MasterLoot:ClearDone()
     local newItems = {}
-    for _, item in ipairs(MasterLoot.items) do
+    for _, item in ipairs(self.items) do
         if not item.isDone then
             table.insert(newItems, item)
         end
     end
-    MasterLoot.items = newItems
+    self.items = newItems
 
     if LootyUI and LootyUI.Refresh then
         LootyUI:Refresh()
     end
 end
-
--- ---- Toggle Item Done ----
-
-function MasterLoot:ToggleDone(itemIndex)
-    local item = MasterLoot.items[itemIndex]
-    if not item then return end
-
-    item.isDone = not item.isDone
-
-    -- Sync: notify raid members (ML only)
-    if MasterLoot.isML then
-        MasterLoot:SendThrottledMessage("ITEM_DONE|" .. itemIndex)
-    end
-
-    if LootyUI and LootyUI.Refresh then
-        LootyUI:Refresh()
-    end
-end
-
--- ---- Cancel Current Roll ----
-
-function MasterLoot:CancelRoll()
-    if not MasterLoot.currentRoll then return end
-    local item = MasterLoot.items[MasterLoot.currentRoll]
-    if not item then return end
-
-    item.rolling = false
-    item.rollStart = nil
-    MasterLoot.currentRoll = nil
-    if MasterLoot.rollTimer then
-        MasterLoot.rollTimer:Hide()
-        MasterLoot.rollTimer = nil
-    end
-
-    if LootyUI and LootyUI.Refresh then
-        LootyUI:Refresh()
-    end
-end
-
--- ---- Get Items by State ----
 
 function MasterLoot:GetPendingItems()
     local items = {}
-    for _, item in ipairs(MasterLoot.items) do
+    for _, item in ipairs(self.items) do
         if not item.isDone then
             table.insert(items, item)
         end
@@ -591,7 +650,6 @@ end
 
 function MasterLoot:GetDoneItems()
     local items = {}
-    -- Iterate backwards so most recent done items appear first
     for i = #self.items, 1, -1 do
         if self.items[i].isDone then
             table.insert(items, self.items[i])
@@ -600,170 +658,162 @@ function MasterLoot:GetDoneItems()
     return items
 end
 
--- ---- Get Active Item Count ----
-
 function MasterLoot:GetActiveItemCount()
     local count = 0
-    for _, item in ipairs(MasterLoot.items) do
-        if not item.isDone then
-            count = count + 1
-        end
+    for _, item in ipairs(self.items) do
+        if not item.isDone then count = count + 1 end
     end
     return count
 end
 
+-- ============================================================
 -- ---- Test Data Injection ----
+-- ============================================================
 
 function MasterLoot:InjectTestRolls()
-    MasterLoot.active = true
-    MasterLoot.isML = true
-    MasterLoot.items = {
+    self.isMasterLootActive = true
+    self.active = true
+    self.role   = "MasterLooter"
+    self.isML   = true
+    self.items  = {
         {
-            slot = 1,
-            name = "Spinal Crusher",
-            link = "|cffa335ee|Hitem:18815:0:0:0:0:0:0:0:0|h[Spinal Crusher]|h|r",
-            texture = "Interface\\Icons\\INV_Mace_36",
-            quantity = 1,
-            quality = 4,
-            rolling = true,
+            slot      = 1,
+            name      = "Spinal Crusher",
+            link      = "|cffa335ee|Hitem:18815:0:0:0:0:0:0:0:0|h[Spinal Crusher]|h|r",
+            texture   = "Interface\\Icons\\INV_Mace_36",
+            quantity  = 1,
+            quality   = 4,
+            rolling   = true,
             rollStart = GetTime(),
-            isDone = false,
-            winner = nil,
+            isDone    = false,
+            winner    = nil,
             rolls = {
-                IronWall   = { value = 45, time = GetTime() },
-                TankJoe    = { value = 73, time = GetTime() },
-                Buenclima  = { value = 22, time = GetTime() },
-                ShadowMaw  = { value = 88, time = GetTime() },
-                HealMePlz  = { value = 15, time = GetTime() },
-                DPSKing    = { value = 61, time = GetTime() },
-                WarriorK   = { value = 94, time = GetTime() },
-                MageBob    = { value = 33, time = GetTime() },
+                IronWall  = { value = 45, time = GetTime() },
+                TankJoe   = { value = 73, time = GetTime() },
+                Buenclima = { value = 22, time = GetTime() },
+                ShadowMaw = { value = 88, time = GetTime() },
+                HealMePlz = { value = 15, time = GetTime() },
+                DPSKing   = { value = 61, time = GetTime() },
+                WarriorK  = { value = 94, time = GetTime() },
+                MageBob   = { value = 33, time = GetTime() },
             },
             rerolls = {
-                DPSKing = { value = 99, time = GetTime() }, -- cheating attempt
+                DPSKing = { value = 99, time = GetTime() },  -- cheating attempt
             },
         },
         {
-            slot = 2,
-            name = "Staff of the Shadowflame",
-            link = "|cffa335ee|Hitem:23243:0:0:0:0:0:0:0:0|h[Staff of the Shadowflame]|h|r",
-            texture = "Interface\\Icons\\INV_Staff_13",
-            quantity = 1,
-            quality = 4,
-            rolling = false,
+            slot      = 2,
+            name      = "Staff of the Shadowflame",
+            link      = "|cffa335ee|Hitem:23243:0:0:0:0:0:0:0:0|h[Staff of the Shadowflame]|h|r",
+            texture   = "Interface\\Icons\\INV_Staff_13",
+            quantity  = 1,
+            quality   = 4,
+            rolling   = false,
             rollStart = nil,
-            isDone = false,
-            winner = nil,
-            rolls = {},
-            rerolls = {},
+            isDone    = false,
+            winner    = nil,
+            rolls     = {},
+            rerolls   = {},
         },
         {
-            slot = 3,
-            name = "Ring of the Eternal",
-            link = "|cff0070dd|Hitem:22734:0:0:0:0:0:0:0:0|h[Ring of the Eternal]|h|r",
-            texture = "Interface\\Icons\\INV_Jewelry_Ring_15",
-            quantity = 1,
-            quality = 3,
-            rolling = false,
+            slot      = 3,
+            name      = "Ring of the Eternal",
+            link      = "|cff0070dd|Hitem:22734:0:0:0:0:0:0:0:0|h[Ring of the Eternal]|h|r",
+            texture   = "Interface\\Icons\\INV_Jewelry_Ring_15",
+            quantity  = 1,
+            quality   = 3,
+            rolling   = false,
             rollStart = nil,
-            isDone = true, -- Already done
-            winner = "HealMePlz",
+            isDone    = true,
+            winner    = "HealMePlz",
             rolls = {
-                HealMePlz  = { value = 87, time = GetTime() },
-                ShadowMaw  = { value = 34, time = GetTime() },
-                MageBob    = { value = 65, time = GetTime() },
+                HealMePlz = { value = 87, time = GetTime() },
+                ShadowMaw = { value = 34, time = GetTime() },
+                MageBob   = { value = 65, time = GetTime() },
             },
             rerolls = {},
         },
     }
-    MasterLoot.currentRoll = 1
+    self.currentRoll = 1
 
-    addon:Print("Master Loot test data injected — 2 pending, 1 done.")
+    addon:Print("Master Loot test data injected — 2 pending, 1 done. Role: MasterLooter")
 
-    if LootyUI and LootyUI.SwitchTab then
-        LootyUI:SwitchTab("master")
-    end
-    if LootyUI and LootyUI.Refresh then
-        LootyUI:Refresh()
-    end
+    if LootyUI and LootyUI.SwitchTab then LootyUI:SwitchTab("master") end
+    if LootyUI and LootyUI.Refresh   then LootyUI:Refresh() end
 end
 
--- ---- Inject Remote Test Data (simulate receiving items from ML) ----
-
 function MasterLoot:InjectRemoteTest()
-    -- Simulate remote mode with test items
+    self.isMasterLootActive = true
+    self.active     = true
+    self.role       = "Raider"
+    self.isML       = false
     self.remoteMode = true
-    self.remoteML = "TestMaster"
-
+    self.remoteML   = "TestMaster"
     self.remoteItems = {
         [1] = {
-            index = 1,
-            slot = 1,
-            name = "Spinal Crusher",
-            link = "|cffa335ee|Hitem:18815:0:0:0:0:0:0:0|h[Spinal Crusher]|h|r",
-            texture = "Interface\\Icons\\INV_Mace_36",
-            quantity = 1,
-            quality = 4,
-            rolling = true,
+            index     = 1,
+            slot      = 1,
+            name      = "Spinal Crusher",
+            link      = "|cffa335ee|Hitem:18815:0:0:0:0:0:0:0|h[Spinal Crusher]|h|r",
+            texture   = "Interface\\Icons\\INV_Mace_36",
+            quantity  = 1,
+            quality   = 4,
+            rolling   = true,
             rollStart = GetTime(),
-            isDone = false,
-            winner = nil,
+            isDone    = false,
+            winner    = nil,
             rolls = {
-                IronWall   = { value = 45, time = GetTime() },
-                TankJoe    = { value = 73, time = GetTime() },
-                Buenclima  = { value = 22, time = GetTime() },
-                ShadowMaw  = { value = 88, time = GetTime() },
-                HealMePlz  = { value = 15, time = GetTime() },
-                DPSKing    = { value = 61, time = GetTime() },
-                WarriorK   = { value = 94, time = GetTime() },
-                MageBob    = { value = 33, time = GetTime() },
+                IronWall  = { value = 45, time = GetTime() },
+                TankJoe   = { value = 73, time = GetTime() },
+                Buenclima = { value = 22, time = GetTime() },
+                ShadowMaw = { value = 88, time = GetTime() },
+                HealMePlz = { value = 15, time = GetTime() },
+                DPSKing   = { value = 61, time = GetTime() },
+                WarriorK  = { value = 94, time = GetTime() },
+                MageBob   = { value = 33, time = GetTime() },
             },
             rerolls = {
-                DPSKing = { value = 99, time = GetTime() }, -- cheating attempt
+                DPSKing = { value = 99, time = GetTime() },
             },
         },
         [2] = {
-            index = 2,
-            slot = 2,
-            name = "Staff of the Shadowflame",
-            link = "|cffa335ee|Hitem:23243:0:0:0:0:0:0:0|h[Staff of the Shadowflame]|h|r",
-            texture = "Interface\\Icons\\INV_Staff_13",
-            quantity = 1,
-            quality = 4,
-            rolling = false,
+            index     = 2,
+            slot      = 2,
+            name      = "Staff of the Shadowflame",
+            link      = "|cffa335ee|Hitem:23243:0:0:0:0:0:0:0|h[Staff of the Shadowflame]|h|r",
+            texture   = "Interface\\Icons\\INV_Staff_13",
+            quantity  = 1,
+            quality   = 4,
+            rolling   = false,
             rollStart = nil,
-            isDone = false,
-            winner = nil,
-            rolls = {},
-            rerolls = {},
+            isDone    = false,
+            winner    = nil,
+            rolls     = {},
+            rerolls   = {},
         },
         [3] = {
-            index = 3,
-            slot = 3,
-            name = "Ring of the Eternal",
-            link = "|cff0070dd|Hitem:22734:0:0:0:0:0:0:0|h[Ring of the Eternal]|h|r",
-            texture = "Interface\\Icons\\INV_Jewelry_Ring_15",
-            quantity = 1,
-            quality = 3,
-            rolling = false,
+            index     = 3,
+            slot      = 3,
+            name      = "Ring of the Eternal",
+            link      = "|cff0070dd|Hitem:22734:0:0:0:0:0:0:0|h[Ring of the Eternal]|h|r",
+            texture   = "Interface\\Icons\\INV_Jewelry_Ring_15",
+            quantity  = 1,
+            quality   = 3,
+            rolling   = false,
             rollStart = nil,
-            isDone = true, -- Already done
-            winner = "HealMePlz",
+            isDone    = true,
+            winner    = "HealMePlz",
             rolls = {
-                HealMePlz  = { value = 87, time = GetTime() },
-                ShadowMaw  = { value = 34, time = GetTime() },
-                MageBob    = { value = 65, time = GetTime() },
+                HealMePlz = { value = 87, time = GetTime() },
+                ShadowMaw = { value = 34, time = GetTime() },
+                MageBob   = { value = 65, time = GetTime() },
             },
             rerolls = {},
         },
     }
 
-    addon:Print("Remote test data injected — 2 pending, 1 done. ML: TestMaster")
+    addon:Print("Remote test data injected — 2 pending, 1 done. Role: Raider  ML: TestMaster")
 
-    if LootyUI and LootyUI.SwitchTab then
-        LootyUI:SwitchTab("master")
-    end
-    if LootyUI and LootyUI.Refresh then
-        LootyUI:Refresh()
-    end
+    if LootyUI and LootyUI.SwitchTab then LootyUI:SwitchTab("master") end
+    if LootyUI and LootyUI.Refresh   then LootyUI:Refresh() end
 end

--- a/MasterLoot.lua
+++ b/MasterLoot.lua
@@ -32,13 +32,16 @@ MasterLoot.rollTimer   = nil  -- Frame for roll countdown
 MasterLoot.rollDuration = 30  -- Seconds for each roll
 
 -- Remote state (for Raider clients receiving sync from ML)
-MasterLoot.remoteMode  = false  -- true once role is "Raider" and ML mode is active
-MasterLoot.remoteItems = {}     -- Mirror of ML's items (indexed by item index)
-MasterLoot.remoteML    = nil    -- Name of the ML we are tracking
+MasterLoot.remoteMode       = false  -- true once role is "Raider" and ML mode is active
+MasterLoot.remoteItems      = {}     -- Mirror of ML's items (indexed by item index)
+MasterLoot.remoteML         = nil    -- Name of the ML we are tracking
+MasterLoot.currentRemoteRoll = nil   -- Index of the remoteItem currently rolling (Raider side)
 
 -- Throttle for SendAddonMessage (WoW 3.3.5 rate-limit protection).
--- Items are queued and sent one by one with a 0.5 s gap.
-MasterLoot.msgThrottle  = 0.5  -- Min seconds between auto-messages
+-- 0.1 s = max 10 msgs/s × ~120 bytes = ~1200 CPS, well within ChatThrottleLib's
+-- researched safe limit of 800 CPS sustained / 4000-byte burst before disconnect.
+-- A 25-man full boss loot (~30 msgs, ~3600 bytes) completes in ~3 s at this rate.
+MasterLoot.msgThrottle  = 0.1  -- Min seconds between auto-messages
 MasterLoot.lastMsgTime  = 0    -- Timestamp of last message sent
 MasterLoot.pendingItems = {}   -- Queue for messages waiting to be sent
 MasterLoot.sendTimer    = nil  -- Timer frame for throttled sending
@@ -334,10 +337,11 @@ function MasterLoot:OnAddonMessage(prefix, message, distribution, sender)
     elseif string.sub(message, 1, 11) == "ROLL_START" .. SEP then
         local idx = tonumber(string.sub(message, 12))
         if idx and self.remoteItems[idx] then
-            self.remoteItems[idx].rolling   = true
-            self.remoteItems[idx].rollStart = GetTime()
-            self.remoteItems[idx].rolls     = {}
-            self.remoteItems[idx].rerolls   = {}
+            self.remoteItems[idx].rolling    = true
+            self.remoteItems[idx].rollStart  = GetTime()
+            self.remoteItems[idx].rolls      = {}
+            self.remoteItems[idx].rerolls    = {}
+            self.currentRemoteRoll           = idx  -- track for Raider roll capture
         end
 
     elseif string.sub(message, 1, 9) == "ROLL_END" .. SEP then
@@ -355,6 +359,7 @@ function MasterLoot:OnAddonMessage(prefix, message, distribution, sender)
             self.remoteItems[idx].rollStart = nil
             self.remoteItems[idx].winner    = (winner and winner ~= "none") and winner or nil
         end
+        self.currentRemoteRoll = nil  -- roll over, stop capturing
 
     elseif string.sub(message, 1, 10) == "ITEM_DONE" .. SEP then
         local idx = tonumber(string.sub(message, 11))
@@ -558,17 +563,31 @@ function MasterLoot:CreateTimer(itemIndex)
 end
 
 -- ============================================================
--- ---- Roll recording (ML side, driven by Parser) ----
+-- ---- Roll recording (ML and Raider, driven by Parser) ----
 -- ============================================================
 
 function MasterLoot:RecordRoll(playerName, value, itemName)
     if not self.active then return end
-    if not self.currentRoll then return end
 
-    local item = self.items[self.currentRoll]
+    local item
+
+    if self.isML then
+        -- ML path: use its own items table and currentRoll index
+        if not self.currentRoll then return end
+        item = self.items[self.currentRoll]
+    elseif self.remoteMode then
+        -- Raider path: use remoteItems and currentRemoteRoll index.
+        -- CHAT_MSG_SYSTEM fires locally for all group members, so Raiders
+        -- receive the same /roll messages as the ML without any extra protocol.
+        if not self.currentRemoteRoll then return end
+        item = self.remoteItems[self.currentRemoteRoll]
+    else
+        return
+    end
+
     if not item or not item.rolling then return end
 
-    -- Duplicate roll → cheating detection
+    -- Duplicate roll → cheating detection (same logic for both roles)
     if item.rolls[playerName] then
         item.rerolls[playerName] = { value = value, time = GetTime() }
         if addon.db and addon.db.debug then
@@ -656,6 +675,34 @@ function MasterLoot:GetDoneItems()
         end
     end
     return items
+end
+
+-- Raider equivalents: operate on remoteItems (sparse table, iterate by index)
+function MasterLoot:GetRemoteDoneItems()
+    local items = {}
+    -- Collect indices first so we can sort them descending (most recent last = first in list)
+    local indices = {}
+    for idx in pairs(self.remoteItems) do
+        table.insert(indices, idx)
+    end
+    table.sort(indices, function(a, b) return a > b end)
+    for _, idx in ipairs(indices) do
+        if self.remoteItems[idx].isDone then
+            table.insert(items, self.remoteItems[idx])
+        end
+    end
+    return items
+end
+
+function MasterLoot:ClearRemoteDone()
+    for idx in pairs(self.remoteItems) do
+        if self.remoteItems[idx].isDone then
+            self.remoteItems[idx] = nil
+        end
+    end
+    if LootyUI and LootyUI.Refresh then
+        LootyUI:Refresh()
+    end
 end
 
 function MasterLoot:GetActiveItemCount()

--- a/MasterLoot.lua
+++ b/MasterLoot.lua
@@ -97,6 +97,7 @@ local function CheckIsML()
     --   masterlooterPartyID = 0 means THIS PLAYER is ML
     --   masterlooterPartyID = 1-4 means party member 1-4 is ML
     --   masterlooterRaidID = raid index or nil
+    -- TODO: Check for current player raidID and compare with masterlooterPartyID: see https://web.archive.org/web/20100513002458/http://wowprogramming.com/docs/api/GetLootMethod
     if masterlooterPartyID == 0 then
         MasterLoot.isML = true
         return true

--- a/MasterLoot.lua
+++ b/MasterLoot.lua
@@ -16,6 +16,73 @@ MasterLoot.rollTimer = nil      -- Frame for roll countdown
 MasterLoot.rollDuration = 30    -- Seconds for each roll
 MasterLoot.isML = false         -- Is current player the Master Looter?
 
+-- Remote state (for non-ML clients receiving sync from ML)
+MasterLoot.remoteMode = false    -- Are we in remote spectator mode?
+MasterLoot.remoteItems = {}      -- Mirror of ML's items (indexed by index)
+MasterLoot.remoteML = nil        -- Name of ML we're tracking
+
+-- Throttle for sending messages (rate limit protection)
+-- WoW 3.3.5 has rate limiting on SendAddonMessage - sending too many
+-- messages too fast can disconnect the player. We use 0.5s between messages.
+-- Items are queued and sent one by one with this delay.
+MasterLoot.msgThrottle = 0.5    -- Min seconds between auto-messages
+MasterLoot.lastMsgTime = 0      -- Timestamp of last message sent
+MasterLoot.pendingItems = {}     -- Queue for items waiting to be sent
+MasterLoot.sendTimer = nil       -- Timer frame for throttled sending
+
+-- Message Protocol (prefix: "LOOTY")
+-- ITEM|index|link|texture|quality|name  → One per item, 0.5s apart
+-- ROLL_START|index                      → Roll started for item
+-- ROLL_END|index|winnerName          → Roll ended, winner announced
+-- ITEM_DONE|index                      → Item marked as done
+-- CLEAR                               → All items cleared (ML mode off)
+
+-- ---- Message Sending (ML side) ----
+
+function MasterLoot:SendThrottledMessage(msg)
+    if not self.isML then return end
+    -- Add to queue
+    table.insert(self.pendingItems, msg)
+    self:ProcessSendQueue()
+end
+
+function MasterLoot:ProcessSendQueue()
+    if #self.pendingItems == 0 then return end
+    if GetTime() - self.lastMsgTime < self.msgThrottle then
+        -- Schedule timer to try again
+        if not self.sendTimer then
+            self.sendTimer = CreateFrame("Frame")
+            self.sendTimer:SetScript("OnUpdate", function(self)
+                MasterLoot:ProcessSendQueue()
+            end)
+        end
+        self.sendTimer:Show()
+        return
+    end
+
+    -- Send next message
+    local msg = table.remove(self.pendingItems, 1)
+    SendAddonMessage("LOOTY", msg, "RAID")
+    self.lastMsgTime = GetTime()
+
+    -- If more items, will be picked up on next OnUpdate
+    if #self.pendingItems == 0 and self.sendTimer then
+        self.sendTimer:Hide()
+    end
+end
+
+function MasterLoot:SerializeItem(item, index)
+    -- Compact format: ITEM|index|link|texture|quality|name
+    -- Escape pipe characters in link (safety measure)
+    local link = string.gsub(item.link or "", "|", "||")
+    local texture = item.texture or ""
+    local quality = tostring(item.quality or 2)
+    local name = item.name or "Unknown"
+
+    return string.format("ITEM|%d|%s|%s|%s|%s",
+        index, link, texture, quality, name)
+end
+
 -- ---- Helper: check if player is Master Looter ----
 
 local function CheckIsML()
@@ -94,6 +161,19 @@ function MasterLoot:OnLootMethodChanged()
         MasterLoot.items = {}
         MasterLoot.currentRoll = nil
         MasterLoot.rollTimer = nil
+
+        -- Sync: notify raid members that ML mode is off (ML only)
+        if MasterLoot.isML then
+            MasterLoot:SendThrottledMessage("CLEAR")
+        end
+
+        -- Clear remote state if we were in remote mode (non-ML clients)
+        if MasterLoot.remoteMode then
+            MasterLoot.remoteItems = {}
+            MasterLoot.remoteMode = false
+            MasterLoot.remoteML = nil
+        end
+
         if addon.db and addon.db.debug then
             DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00[LOOTY ML]|r Master Loot mode deactivated.")
         end
@@ -108,10 +188,117 @@ function MasterLoot:OnLootMethodChanged()
                 LootyUI:SwitchTab("grouplot")
             end
         end
-        if LootyUI and LootyUI.Refresh then
-            LootyUI:Refresh()
+    if LootyUI and LootyUI.Refresh then
+        LootyUI:Refresh()
+    end
+end
+
+-- ---- Message Receiving (All clients) ----
+
+function MasterLoot:DeserializeItem(message)
+    -- Parse: ITEM|index|link|texture|quality|name
+    -- Link may contain escaped pipes (||), need to handle carefully
+    local header, rest = string.match(message, "^ITEM|(.+)$")
+    if not header then return nil end
+
+    -- Split by | but respect escaped ||
+    local parts = {}
+    local current = ""
+    local i = 1
+    while i <= #rest do
+        local char = string.sub(rest, i, i)
+        if char == "|" and i < #rest and string.sub(rest, i+1, i+1) == "|" then
+            current = current .. "|"
+            i = i + 2
+        elseif char == "|" then
+            table.insert(parts, current)
+            current = ""
+            i = i + 1
+        else
+            current = current .. char
+            i = i + 1
         end
     end
+    table.insert(parts, current)  -- Last part
+
+    if #parts < 5 then return nil end
+
+    return {
+        index = tonumber(parts[1]),
+        link = string.gsub(parts[2], "||", "|"),  -- Unescape
+        texture = parts[3],
+        quality = tonumber(parts[4]) or 2,
+        name = parts[5],
+        -- Initialize other fields
+        slot = tonumber(parts[1]) or 0,
+        quantity = 1,
+        rolls = {},
+        rerolls = {},
+        rolling = false,
+        rollStart = nil,
+        isDone = false,
+        winner = nil,
+    }
+end
+
+function MasterLoot:OnAddonMessage(prefix, message, distribution, sender)
+    -- Only process messages for Looty
+    if prefix ~= "LOOTY" then return end
+    -- ML doesn't process own messages
+    if self.isML then return end
+
+    -- Set remote mode on first ITEM received
+    if not self.remoteMode and string.find(message, "^ITEM|") then
+        self.remoteMode = true
+        self.remoteML = sender
+        if addon.db and addon.db.debug then
+            DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00[LOOTY ML]|r Remote mode activated, ML: " .. sender)
+        end
+    end
+
+    -- Parse commands
+    if string.find(message, "^ITEM|") then
+        local item = self:DeserializeItem(message)
+        if item then
+            self.remoteItems[item.index] = item
+            if addon.db and addon.db.debug then
+                DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00[LOOTY ML]|r Received item: " .. item.name)
+            end
+        end
+    elseif string.find(message, "^ROLL_START|") then
+        local _, _, idx = string.find(message, "ROLL_START|(%d+)")
+        idx = tonumber(idx)
+        if idx and self.remoteItems[idx] then
+            self.remoteItems[idx].rolling = true
+            self.remoteItems[idx].rollStart = GetTime()
+            self.remoteItems[idx].rolls = {}
+            self.remoteItems[idx].rerolls = {}
+        end
+    elseif string.find(message, "^ROLL_END|") then
+        local _, _, idx, winner = string.find(message, "ROLL_END|(%d+)|(.+)")
+        idx = tonumber(idx)
+        if idx and self.remoteItems[idx] then
+            self.remoteItems[idx].rolling = false
+            self.remoteItems[idx].rollStart = nil
+            self.remoteItems[idx].winner = winner ~= "none" and winner or nil
+        end
+    elseif string.find(message, "^ITEM_DONE|") then
+        local _, _, idx = string.find(message, "ITEM_DONE|(%d+)")
+        idx = tonumber(idx)
+        if idx and self.remoteItems[idx] then
+            self.remoteItems[idx].isDone = true
+        end
+    elseif message == "CLEAR" then
+        self.remoteItems = {}
+        self.remoteMode = false
+        self.remoteML = nil
+    end
+
+    -- Refresh UI
+    if LootyUI and LootyUI.Refresh then
+        LootyUI:Refresh()
+    end
+end
 end
 
 -- ---- Event: LOOT_OPENED ----
@@ -161,6 +348,14 @@ function MasterLoot:OnLootOpened()
         end
     end
 
+    -- Send items to raid members (one per message, 0.5s throttle)
+    if self.isML then
+        for index, item in ipairs(MasterLoot.items) do
+            local msg = self:SerializeItem(item, index)
+            self:SendThrottledMessage(msg)
+        end
+    end
+
     if addon.db and addon.db.debug then
         DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00[LOOTY ML]|r Loot opened: " .. #MasterLoot.items .. " items found.")
     end
@@ -200,6 +395,11 @@ function MasterLoot:StartRoll(itemIndex)
     SendChatMessage(msg, "RAID_WARNING")
     addon:Print(msg)
 
+    -- Sync: notify raid members (ML only)
+    if MasterLoot.isML then
+        MasterLoot:SendThrottledMessage("ROLL_START|" .. itemIndex)
+    end
+
     -- Start countdown timer
     MasterLoot.rollTimer = MasterLoot:CreateTimer(itemIndex)
 
@@ -229,6 +429,11 @@ function MasterLoot:EndRoll(itemIndex)
         addon:Print(announceMsg)
     else
         addon:Print("No rolls for " .. (item.link or item.name))
+    end
+
+    -- Sync: notify raid members (ML only)
+    if MasterLoot.isML then
+        MasterLoot:SendThrottledMessage("ROLL_END|" .. itemIndex .. "|" .. (winner or "none"))
     end
 
     if LootyUI and LootyUI.Refresh then
@@ -340,6 +545,11 @@ function MasterLoot:ToggleDone(itemIndex)
     if not item then return end
 
     item.isDone = not item.isDone
+
+    -- Sync: notify raid members (ML only)
+    if MasterLoot.isML then
+        MasterLoot:SendThrottledMessage("ITEM_DONE|" .. itemIndex)
+    end
 
     if LootyUI and LootyUI.Refresh then
         LootyUI:Refresh()
@@ -468,6 +678,86 @@ function MasterLoot:InjectTestRolls()
     MasterLoot.currentRoll = 1
 
     addon:Print("Master Loot test data injected — 2 pending, 1 done.")
+
+    if LootyUI and LootyUI.SwitchTab then
+        LootyUI:SwitchTab("master")
+    end
+    if LootyUI and LootyUI.Refresh then
+        LootyUI:Refresh()
+    end
+end
+
+-- ---- Inject Remote Test Data (simulate receiving items from ML) ----
+
+function MasterLoot:InjectRemoteTest()
+    -- Simulate remote mode with test items
+    self.remoteMode = true
+    self.remoteML = "TestMaster"
+
+    self.remoteItems = {
+        [1] = {
+            index = 1,
+            slot = 1,
+            name = "Spinal Crusher",
+            link = "|cffa335ee|Hitem:18815:0:0:0:0:0:0:0|h[Spinal Crusher]|h|r",
+            texture = "Interface\\Icons\\INV_Mace_36",
+            quantity = 1,
+            quality = 4,
+            rolling = true,
+            rollStart = GetTime(),
+            isDone = false,
+            winner = nil,
+            rolls = {
+                IronWall   = { value = 45, time = GetTime() },
+                TankJoe    = { value = 73, time = GetTime() },
+                Buenclima  = { value = 22, time = GetTime() },
+                ShadowMaw  = { value = 88, time = GetTime() },
+                HealMePlz  = { value = 15, time = GetTime() },
+                DPSKing    = { value = 61, time = GetTime() },
+                WarriorK   = { value = 94, time = GetTime() },
+                MageBob    = { value = 33, time = GetTime() },
+            },
+            rerolls = {
+                DPSKing = { value = 99, time = GetTime() }, -- cheating attempt
+            },
+        },
+        [2] = {
+            index = 2,
+            slot = 2,
+            name = "Staff of the Shadowflame",
+            link = "|cffa335ee|Hitem:23243:0:0:0:0:0:0:0|h[Staff of the Shadowflame]|h|r",
+            texture = "Interface\\Icons\\INV_Staff_13",
+            quantity = 1,
+            quality = 4,
+            rolling = false,
+            rollStart = nil,
+            isDone = false,
+            winner = nil,
+            rolls = {},
+            rerolls = {},
+        },
+        [3] = {
+            index = 3,
+            slot = 3,
+            name = "Ring of the Eternal",
+            link = "|cff0070dd|Hitem:22734:0:0:0:0:0:0:0|h[Ring of the Eternal]|h|r",
+            texture = "Interface\\Icons\\INV_Jewelry_Ring_15",
+            quantity = 1,
+            quality = 3,
+            rolling = false,
+            rollStart = nil,
+            isDone = true, -- Already done
+            winner = "HealMePlz",
+            rolls = {
+                HealMePlz  = { value = 87, time = GetTime() },
+                ShadowMaw  = { value = 34, time = GetTime() },
+                MageBob    = { value = 65, time = GetTime() },
+            },
+            rerolls = {},
+        },
+    }
+
+    addon:Print("Remote test data injected — 2 pending, 1 done. ML: TestMaster")
 
     if LootyUI and LootyUI.SwitchTab then
         LootyUI:SwitchTab("master")

--- a/MasterLoot.lua
+++ b/MasterLoot.lua
@@ -48,16 +48,21 @@ MasterLoot.sendTimer    = nil  -- Timer frame for throttled sending
 
 -- Message Protocol (prefix: "LOOTY")
 -- Field separator: \001 (ASCII SOH) — cannot appear in item links or names.
--- ITEM\001index\001link\001texture\001quality\001name      → One per item, 0.1 s apart
--- ROLL_START\001index                                      → Roll started for item
--- ROLL_END\001index\001winnerName                          → Roll ended, winner announced
--- ITEM_DONE\001index                                       → Item marked as done
--- CLEAR_DONE\001idx1\001idx2\001...                        → ML cleared specific done items
--- CLEAR                                                    → All items cleared (ML mode off)
 --
--- IMPORTANT: item indices in all messages are the ORIGINAL indices from LOOT_OPENED.
--- ClearDone on the ML side MUST NOT compact self.items — it nils entries in-place
--- so that all subsequent index-keyed messages still match the Raider's remoteItems.
+-- Item identity key: "{itemID}:{slot}"  e.g. "18815:3"
+--   - itemID extracted from the item link (|Hitem:ITEMID:...|h)
+--   - slot is the loot slot index from GetLootSlotLink(i), stable for the session
+--   - Composite key handles duplicate drops of the same item (same itemID, different slot)
+--   - Both ML and Raiders key their item tables on this string — no positional indices
+--
+-- ITEM\001itemKey\001link\001texture\001quality\001name  → One per item, 0.1 s apart
+-- ROLL_START\001itemKey                                  → Roll started for item
+-- ROLL_END\001itemKey\001winnerName                      → Roll ended, winner announced
+-- ITEM_DONE\001itemKey                                   → Item loot session finalized
+-- CLEAR                                                  → All items cleared (ML mode off)
+--
+-- NOTE: ClearDone is a LOCAL UI operation on both ML and Raider — it does NOT send a
+-- protocol message. Each client manages its own Done/History view independently.
 
 -- ============================================================
 -- ---- Internal helpers: loot method and ML detection ----
@@ -199,19 +204,24 @@ end
 
 -- Field separator: ASCII \001 (SOH).
 -- Cannot appear in item links, texture paths, quality digits, or item names.
--- This avoids the pipe-escaping problem entirely — WoW item links contain many
--- literal | characters (|c color codes, |H hyperlinks, |h display text, |r reset)
--- that would collide with any pipe-based delimiter scheme.
 local SEP = "\001"
 
-function MasterLoot:SerializeItem(item, index)
-    -- Format: ITEM\001index\001link\001texture\001quality\001name
-    -- No escaping needed — SEP (\001) never appears in any of these fields.
+-- Build the stable identity key for an item: "{itemID}:{slot}"
+-- itemID is extracted from the WoW item link format: |Hitem:ITEMID:...|h
+-- slot is the loot window slot index (server-assigned, stable for the session).
+-- Two drops of the same item get the same itemID but different slots → unique keys.
+local function ExtractItemKey(link, slot)
+    local itemID = string.match(link or "", "item:(%d+)")
+    return (itemID or "0") .. ":" .. tostring(slot)
+end
+
+function MasterLoot:SerializeItem(item)
+    -- Format: ITEM\001itemKey\001link\001texture\001quality\001name
     local link    = item.link or ""
     local texture = item.texture or ""
     local quality = tostring(item.quality or 2)
     local name    = item.name or "Unknown"
-    return "ITEM" .. SEP .. index .. SEP .. link .. SEP .. texture .. SEP .. quality .. SEP .. name
+    return "ITEM" .. SEP .. item.itemKey .. SEP .. link .. SEP .. texture .. SEP .. quality .. SEP .. name
 end
 
 -- ============================================================
@@ -280,29 +290,28 @@ end
 -- ============================================================
 
 function MasterLoot:DeserializeItem(message)
-    -- Format: ITEM\001index\001link\001texture\001quality\001name
-    -- SEP is \001 — split cleanly with no pipe-escaping complications.
+    -- Format: ITEM\001itemKey\001link\001texture\001quality\001name
     if not string.find(message, "^ITEM" .. SEP) then return nil end
 
     local parts = {}
-    -- strsplit does not exist in all Lua environments; use gmatch with SEP
-    -- Note: string.gmatch pattern-escaping — \001 has no special meaning in
-    -- Lua patterns so it can be used directly as a literal character.
     for segment in string.gmatch(message, "[^" .. SEP .. "]+") do
         table.insert(parts, segment)
     end
-    -- parts[1] = "ITEM", parts[2] = index, parts[3] = link, parts[4] = texture,
-    -- parts[5] = quality, parts[6] = name
+    -- parts[1]="ITEM" parts[2]=itemKey parts[3]=link parts[4]=texture
+    -- parts[5]=quality parts[6]=name
     if #parts < 6 then return nil end
 
-    local idx = tonumber(parts[2])
+    local itemKey = parts[2]
+    -- Extract slot from itemKey ("{itemID}:{slot}") for local use
+    local slot = tonumber(string.match(itemKey, ":(%d+)$")) or 0
+
     return {
-        index     = idx,
+        itemKey   = itemKey,
         link      = parts[3],
         texture   = parts[4],
         quality   = tonumber(parts[5]) or 2,
         name      = parts[6],
-        slot      = idx or 0,
+        slot      = slot,
         quantity  = 1,
         rolls     = {},
         rerolls   = {},
@@ -328,65 +337,55 @@ function MasterLoot:OnAddonMessage(prefix, message, distribution, sender)
         end
     end
 
-    -- Dispatch by message type
+    -- All message types below use itemKey (string) as the shared identity key.
     if string.sub(message, 1, #itemPrefix) == itemPrefix then
         local item = self:DeserializeItem(message)
         if item then
-            self.remoteItems[item.index] = item
+            self.remoteItems[item.itemKey] = item
             if addon.db and addon.db.debug then
                 DEFAULT_CHAT_FRAME:AddMessage(
-                    "|cff00ff00[LOOTY ML]|r Raider: received item " .. item.name)
+                    "|cff00ff00[LOOTY ML]|r Raider: received item " .. item.name .. " key=" .. item.itemKey)
             end
         end
 
     elseif string.sub(message, 1, 11) == "ROLL_START" .. SEP then
-        local idx = tonumber(string.sub(message, 12))
-        if idx and self.remoteItems[idx] then
-            self.remoteItems[idx].rolling    = true
-            self.remoteItems[idx].rollStart  = GetTime()
-            self.remoteItems[idx].rolls      = {}
-            self.remoteItems[idx].rerolls    = {}
-            self.currentRemoteRoll           = idx  -- track for Raider roll capture
+        local itemKey = string.sub(message, 12)
+        if itemKey ~= "" and self.remoteItems[itemKey] then
+            self.remoteItems[itemKey].rolling    = true
+            self.remoteItems[itemKey].rollStart  = GetTime()
+            self.remoteItems[itemKey].rolls      = {}
+            self.remoteItems[itemKey].rerolls    = {}
+            self.currentRemoteRoll               = itemKey
         end
 
     elseif string.sub(message, 1, 9) == "ROLL_END" .. SEP then
         local rest   = string.sub(message, 10)
         local sepPos = string.find(rest, SEP, 1, true)
-        local idx, winner
+        local itemKey, winner
         if sepPos then
-            idx    = tonumber(string.sub(rest, 1, sepPos - 1))
-            winner = string.sub(rest, sepPos + 1)
+            itemKey = string.sub(rest, 1, sepPos - 1)
+            winner  = string.sub(rest, sepPos + 1)
         else
-            idx = tonumber(rest)
+            itemKey = rest
         end
-        if idx and self.remoteItems[idx] then
-            self.remoteItems[idx].rolling   = false
-            self.remoteItems[idx].rollStart = nil
-            self.remoteItems[idx].winner    = (winner and winner ~= "none") and winner or nil
+        if itemKey ~= "" and self.remoteItems[itemKey] then
+            self.remoteItems[itemKey].rolling   = false
+            self.remoteItems[itemKey].rollStart = nil
+            self.remoteItems[itemKey].winner    = (winner and winner ~= "none") and winner or nil
         end
-        self.currentRemoteRoll = nil  -- roll over, stop capturing
+        self.currentRemoteRoll = nil
 
     elseif string.sub(message, 1, 10) == "ITEM_DONE" .. SEP then
-        local idx = tonumber(string.sub(message, 11))
-        if idx and self.remoteItems[idx] then
-            self.remoteItems[idx].isDone = true
-        end
-
-    elseif string.sub(message, 1, 11) == "CLEAR_DONE" .. SEP then
-        -- ML cleared specific done items by index. Remove only those indices
-        -- so that active items and their indices are preserved intact.
-        local rest = string.sub(message, 12)
-        for segment in string.gmatch(rest, "[^" .. SEP .. "]+") do
-            local idx = tonumber(segment)
-            if idx then
-                self.remoteItems[idx] = nil
-            end
+        local itemKey = string.sub(message, 11)
+        if itemKey ~= "" and self.remoteItems[itemKey] then
+            self.remoteItems[itemKey].isDone = true
         end
 
     elseif message == "CLEAR" then
-        self.remoteItems = {}
-        self.remoteMode  = false
-        self.remoteML    = nil
+        self.remoteItems      = {}
+        self.remoteMode       = false
+        self.remoteML         = nil
+        self.currentRemoteRoll = nil
     end
 
     if LootyUI and LootyUI.Refresh then
@@ -425,7 +424,9 @@ function MasterLoot:OnLootOpened()
         -- WOTLK 3.3.5 has no GetLootSlotType; filter money by absence of link
         local link = GetLootSlotLink(i)
         if name and link then
-            table.insert(self.items, {
+            local itemKey = ExtractItemKey(link, i)
+            self.items[itemKey] = {
+                itemKey   = itemKey,
                 slot      = i,
                 name      = name,
                 link      = link,
@@ -438,15 +439,13 @@ function MasterLoot:OnLootOpened()
                 rollStart = nil,
                 isDone    = false,
                 winner    = nil,
-            })
+            }
         end
     end
 
     -- Broadcast items to Raiders (throttled, 0.1 s apart)
-    -- self.items is a sparse table keyed by slot index — use pairs, not ipairs.
-    for index, item in pairs(self.items) do
-        local msg = self:SerializeItem(item, index)
-        self:SendThrottledMessage(msg)
+    for _, item in pairs(self.items) do
+        self:SendThrottledMessage(self:SerializeItem(item))
     end
 
     if addon.db and addon.db.debug then
@@ -472,8 +471,8 @@ end
 -- ---- Roll management (ML side) ----
 -- ============================================================
 
-function MasterLoot:StartRoll(itemIndex)
-    local item = self.items[itemIndex]
+function MasterLoot:StartRoll(itemKey)
+    local item = self.items[itemKey]
     if not item or item.isDone or item.rolling then return end
 
     -- Cancel any previous active roll
@@ -486,23 +485,23 @@ function MasterLoot:StartRoll(itemIndex)
     item.rolls    = {}
     item.rerolls  = {}
     item.winner   = nil
-    self.currentRoll = itemIndex
+    self.currentRoll = itemKey
 
     local msg = ">> Rolling for: " .. (item.link or item.name) ..
                 " — /roll now! (" .. self.rollDuration .. "s)"
     SendChatMessage(msg, "RAID_WARNING")
     addon:Print(msg)
 
-        self:SendThrottledMessage("ROLL_START" .. SEP .. itemIndex)
-    self.rollTimer = self:CreateTimer(itemIndex)
+    self:SendThrottledMessage("ROLL_START" .. SEP .. itemKey)
+    self.rollTimer = self:CreateTimer(itemKey)
 
     if LootyUI and LootyUI.Refresh then
         LootyUI:Refresh()
     end
 end
 
-function MasterLoot:EndRoll(itemIndex)
-    local item = self.items[itemIndex]
+function MasterLoot:EndRoll(itemKey)
+    local item = self.items[itemKey]
     if not item or not item.rolling then return end
 
     item.rolling  = false
@@ -522,7 +521,7 @@ function MasterLoot:EndRoll(itemIndex)
         addon:Print("No rolls for " .. (item.link or item.name))
     end
 
-    self:SendThrottledMessage("ROLL_END" .. SEP .. itemIndex .. SEP .. (winner or "none"))
+    self:SendThrottledMessage("ROLL_END" .. SEP .. itemKey .. SEP .. (winner or "none"))
 
     if LootyUI and LootyUI.Refresh then
         LootyUI:Refresh()
@@ -534,7 +533,7 @@ function MasterLoot:CancelRoll()
     local item = self.items[self.currentRoll]
     if not item then return end
 
-    item.rolling  = false
+    item.rolling   = false
     item.rollStart = nil
     self.currentRoll = nil
 
@@ -552,23 +551,23 @@ end
 -- ---- Timer ----
 -- ============================================================
 
-function MasterLoot:CreateTimer(itemIndex)
+function MasterLoot:CreateTimer(itemKey)
     local timer = CreateFrame("Frame")
-    timer.itemIndex = itemIndex
-    timer.elapsed   = 0
+    timer.itemKey = itemKey
+    timer.elapsed = 0
     timer:Show()
     timer:SetScript("OnUpdate", function(self, elapsed)
         self.elapsed = self.elapsed + elapsed
         if self.elapsed >= 1 then
             self.elapsed = 0
-            local item = MasterLoot.items[self.itemIndex]
+            local item = MasterLoot.items[self.itemKey]
             if item and item.rolling then
                 local remaining = MasterLoot.rollDuration - (GetTime() - item.rollStart)
                 if remaining <= 0 then
-                    MasterLoot:EndRoll(self.itemIndex)
+                    MasterLoot:EndRoll(self.itemKey)
                 else
                     if LootyUI and LootyUI.UpdateMasterLootTimer then
-                        LootyUI:UpdateMasterLootTimer(self.itemIndex, remaining)
+                        LootyUI:UpdateMasterLootTimer(self.itemKey, remaining)
                     end
                 end
             else
@@ -648,12 +647,12 @@ end
 -- ---- Item state helpers ----
 -- ============================================================
 
-function MasterLoot:ToggleDone(itemIndex)
-    local item = self.items[itemIndex]
+function MasterLoot:ToggleDone(itemKey)
+    local item = self.items[itemKey]
     if not item then return end
 
     item.isDone = not item.isDone
-    self:SendThrottledMessage("ITEM_DONE" .. SEP .. itemIndex)
+    self:SendThrottledMessage("ITEM_DONE" .. SEP .. itemKey)
 
     if LootyUI and LootyUI.Refresh then
         LootyUI:Refresh()
@@ -661,24 +660,14 @@ function MasterLoot:ToggleDone(itemIndex)
 end
 
 function MasterLoot:ClearDone()
-    -- Collect indices BEFORE modifying, so we can broadcast them to Raiders.
-    -- MUST nil in-place rather than rebuilding the array — rebuilding would
-    -- shift indices and desync all subsequent ROLL_START/ROLL_END/ITEM_DONE
-    -- messages that Raiders key against original LOOT_OPENED indices.
-    local clearedIndices = {}
-    for idx, item in pairs(self.items) do
+    -- Local UI operation only — no protocol message sent.
+    -- Each client (ML and Raiders) manages their own Done/History view independently.
+    -- itemKey-based identity means there is no index drift risk to worry about.
+    for key, item in pairs(self.items) do
         if item.isDone then
-            clearedIndices[#clearedIndices + 1] = idx
-            self.items[idx] = nil
+            self.items[key] = nil
         end
     end
-
-    -- Notify Raiders to remove the same indices
-    if #clearedIndices > 0 then
-        local msg = "CLEAR_DONE" .. SEP .. table.concat(clearedIndices, SEP)
-        self:SendThrottledMessage(msg)
-    end
-
     if LootyUI and LootyUI.Refresh then
         LootyUI:Refresh()
     end
@@ -694,43 +683,44 @@ function MasterLoot:GetPendingItems()
     return items
 end
 
+-- Sort helper: compare two itemKeys by their slot number descending.
+-- itemKey format is "{itemID}:{slot}" so we extract the slot suffix.
+local function itemKeySlotDesc(a, b)
+    local slotA = tonumber(string.match(a, ":(%d+)$")) or 0
+    local slotB = tonumber(string.match(b, ":(%d+)$")) or 0
+    return slotA > slotB
+end
+
 function MasterLoot:GetDoneItems()
-    -- self.items is sparse after ClearDone — collect indices, sort descending.
     local items = {}
-    local indices = {}
-    for idx in pairs(self.items) do
-        table.insert(indices, idx)
-    end
-    table.sort(indices, function(a, b) return a > b end)
-    for _, idx in ipairs(indices) do
-        if self.items[idx].isDone then
-            table.insert(items, self.items[idx])
+    local keys  = {}
+    for key in pairs(self.items) do table.insert(keys, key) end
+    table.sort(keys, itemKeySlotDesc)
+    for _, key in ipairs(keys) do
+        if self.items[key].isDone then
+            table.insert(items, self.items[key])
         end
     end
     return items
 end
 
--- Raider equivalents: operate on remoteItems (sparse table, iterate by index)
 function MasterLoot:GetRemoteDoneItems()
     local items = {}
-    -- Collect indices first so we can sort them descending (most recent last = first in list)
-    local indices = {}
-    for idx in pairs(self.remoteItems) do
-        table.insert(indices, idx)
-    end
-    table.sort(indices, function(a, b) return a > b end)
-    for _, idx in ipairs(indices) do
-        if self.remoteItems[idx].isDone then
-            table.insert(items, self.remoteItems[idx])
+    local keys  = {}
+    for key in pairs(self.remoteItems) do table.insert(keys, key) end
+    table.sort(keys, itemKeySlotDesc)
+    for _, key in ipairs(keys) do
+        if self.remoteItems[key].isDone then
+            table.insert(items, self.remoteItems[key])
         end
     end
     return items
 end
 
 function MasterLoot:ClearRemoteDone()
-    for idx in pairs(self.remoteItems) do
-        if self.remoteItems[idx].isDone then
-            self.remoteItems[idx] = nil
+    for key in pairs(self.remoteItems) do
+        if self.remoteItems[key].isDone then
+            self.remoteItems[key] = nil
         end
     end
     if LootyUI and LootyUI.Refresh then
@@ -756,7 +746,8 @@ function MasterLoot:InjectTestRolls()
     self.role   = "MasterLooter"
     self.isML   = true
     self.items  = {
-        {
+        ["18815:1"] = {
+            itemKey   = "18815:1",
             slot      = 1,
             name      = "Spinal Crusher",
             link      = "|cffa335ee|Hitem:18815:0:0:0:0:0:0:0:0|h[Spinal Crusher]|h|r",
@@ -778,10 +769,11 @@ function MasterLoot:InjectTestRolls()
                 MageBob   = { value = 33, time = GetTime() },
             },
             rerolls = {
-                DPSKing = { value = 99, time = GetTime() },  -- cheating attempt
+                DPSKing = { value = 99, time = GetTime() },
             },
         },
-        {
+        ["23243:2"] = {
+            itemKey   = "23243:2",
             slot      = 2,
             name      = "Staff of the Shadowflame",
             link      = "|cffa335ee|Hitem:23243:0:0:0:0:0:0:0:0|h[Staff of the Shadowflame]|h|r",
@@ -795,7 +787,8 @@ function MasterLoot:InjectTestRolls()
             rolls     = {},
             rerolls   = {},
         },
-        {
+        ["22734:3"] = {
+            itemKey   = "22734:3",
             slot      = 3,
             name      = "Ring of the Eternal",
             link      = "|cff0070dd|Hitem:22734:0:0:0:0:0:0:0:0|h[Ring of the Eternal]|h|r",
@@ -814,7 +807,7 @@ function MasterLoot:InjectTestRolls()
             rerolls = {},
         },
     }
-    self.currentRoll = 1
+    self.currentRoll = "18815:1"
 
     addon:Print("Master Loot test data injected — 2 pending, 1 done. Role: MasterLooter")
 
@@ -823,15 +816,16 @@ function MasterLoot:InjectTestRolls()
 end
 
 function MasterLoot:InjectRemoteTest()
-    self.isMasterLootActive = true
-    self.active     = true
-    self.role       = "Raider"
-    self.isML       = false
-    self.remoteMode = true
-    self.remoteML   = "TestMaster"
+    self.isMasterLootActive  = true
+    self.active              = true
+    self.role                = "Raider"
+    self.isML                = false
+    self.remoteMode          = true
+    self.remoteML            = "TestMaster"
+    self.currentRemoteRoll   = "18815:1"
     self.remoteItems = {
-        [1] = {
-            index     = 1,
+        ["18815:1"] = {
+            itemKey   = "18815:1",
             slot      = 1,
             name      = "Spinal Crusher",
             link      = "|cffa335ee|Hitem:18815:0:0:0:0:0:0:0|h[Spinal Crusher]|h|r",
@@ -856,8 +850,8 @@ function MasterLoot:InjectRemoteTest()
                 DPSKing = { value = 99, time = GetTime() },
             },
         },
-        [2] = {
-            index     = 2,
+        ["23243:2"] = {
+            itemKey   = "23243:2",
             slot      = 2,
             name      = "Staff of the Shadowflame",
             link      = "|cffa335ee|Hitem:23243:0:0:0:0:0:0:0|h[Staff of the Shadowflame]|h|r",
@@ -871,8 +865,8 @@ function MasterLoot:InjectRemoteTest()
             rolls     = {},
             rerolls   = {},
         },
-        [3] = {
-            index     = 3,
+        ["22734:3"] = {
+            itemKey   = "22734:3",
             slot      = 3,
             name      = "Ring of the Eternal",
             link      = "|cff0070dd|Hitem:22734:0:0:0:0:0:0:0|h[Ring of the Eternal]|h|r",

--- a/MasterLoot.lua
+++ b/MasterLoot.lua
@@ -48,11 +48,16 @@ MasterLoot.sendTimer    = nil  -- Timer frame for throttled sending
 
 -- Message Protocol (prefix: "LOOTY")
 -- Field separator: \001 (ASCII SOH) — cannot appear in item links or names.
--- ITEM\001index\001link\001texture\001quality\001name  → One per item, 0.5 s apart
--- ROLL_START\001index                                  → Roll started for item
--- ROLL_END\001index\001winnerName                      → Roll ended, winner announced
--- ITEM_DONE\001index                                   → Item marked as done
--- CLEAR                                                → All items cleared (ML mode off)
+-- ITEM\001index\001link\001texture\001quality\001name      → One per item, 0.1 s apart
+-- ROLL_START\001index                                      → Roll started for item
+-- ROLL_END\001index\001winnerName                          → Roll ended, winner announced
+-- ITEM_DONE\001index                                       → Item marked as done
+-- CLEAR_DONE\001idx1\001idx2\001...                        → ML cleared specific done items
+-- CLEAR                                                    → All items cleared (ML mode off)
+--
+-- IMPORTANT: item indices in all messages are the ORIGINAL indices from LOOT_OPENED.
+-- ClearDone on the ML side MUST NOT compact self.items — it nils entries in-place
+-- so that all subsequent index-keyed messages still match the Raider's remoteItems.
 
 -- ============================================================
 -- ---- Internal helpers: loot method and ML detection ----
@@ -367,6 +372,17 @@ function MasterLoot:OnAddonMessage(prefix, message, distribution, sender)
             self.remoteItems[idx].isDone = true
         end
 
+    elseif string.sub(message, 1, 11) == "CLEAR_DONE" .. SEP then
+        -- ML cleared specific done items by index. Remove only those indices
+        -- so that active items and their indices are preserved intact.
+        local rest = string.sub(message, 12)
+        for segment in string.gmatch(rest, "[^" .. SEP .. "]+") do
+            local idx = tonumber(segment)
+            if idx then
+                self.remoteItems[idx] = nil
+            end
+        end
+
     elseif message == "CLEAR" then
         self.remoteItems = {}
         self.remoteMode  = false
@@ -426,8 +442,9 @@ function MasterLoot:OnLootOpened()
         end
     end
 
-    -- Broadcast items to Raiders (throttled, 0.5 s apart)
-    for index, item in ipairs(self.items) do
+    -- Broadcast items to Raiders (throttled, 0.1 s apart)
+    -- self.items is a sparse table keyed by slot index — use pairs, not ipairs.
+    for index, item in pairs(self.items) do
         local msg = self:SerializeItem(item, index)
         self:SendThrottledMessage(msg)
     end
@@ -644,13 +661,23 @@ function MasterLoot:ToggleDone(itemIndex)
 end
 
 function MasterLoot:ClearDone()
-    local newItems = {}
-    for _, item in ipairs(self.items) do
-        if not item.isDone then
-            table.insert(newItems, item)
+    -- Collect indices BEFORE modifying, so we can broadcast them to Raiders.
+    -- MUST nil in-place rather than rebuilding the array — rebuilding would
+    -- shift indices and desync all subsequent ROLL_START/ROLL_END/ITEM_DONE
+    -- messages that Raiders key against original LOOT_OPENED indices.
+    local clearedIndices = {}
+    for idx, item in pairs(self.items) do
+        if item.isDone then
+            clearedIndices[#clearedIndices + 1] = idx
+            self.items[idx] = nil
         end
     end
-    self.items = newItems
+
+    -- Notify Raiders to remove the same indices
+    if #clearedIndices > 0 then
+        local msg = "CLEAR_DONE" .. SEP .. table.concat(clearedIndices, SEP)
+        self:SendThrottledMessage(msg)
+    end
 
     if LootyUI and LootyUI.Refresh then
         LootyUI:Refresh()
@@ -659,7 +686,7 @@ end
 
 function MasterLoot:GetPendingItems()
     local items = {}
-    for _, item in ipairs(self.items) do
+    for _, item in pairs(self.items) do
         if not item.isDone then
             table.insert(items, item)
         end
@@ -668,10 +695,16 @@ function MasterLoot:GetPendingItems()
 end
 
 function MasterLoot:GetDoneItems()
+    -- self.items is sparse after ClearDone — collect indices, sort descending.
     local items = {}
-    for i = #self.items, 1, -1 do
-        if self.items[i].isDone then
-            table.insert(items, self.items[i])
+    local indices = {}
+    for idx in pairs(self.items) do
+        table.insert(indices, idx)
+    end
+    table.sort(indices, function(a, b) return a > b end)
+    for _, idx in ipairs(indices) do
+        if self.items[idx].isDone then
+            table.insert(items, self.items[idx])
         end
     end
     return items
@@ -707,7 +740,7 @@ end
 
 function MasterLoot:GetActiveItemCount()
     local count = 0
-    for _, item in ipairs(self.items) do
+    for _, item in pairs(self.items) do
         if not item.isDone then count = count + 1 end
     end
     return count

--- a/UI.lua
+++ b/UI.lua
@@ -63,6 +63,10 @@ local classCache = {}
 --   2. Raid roster (GetRaidRosterInfo)
 --   3. Party roster (UnitClass on party units)
 --   4. Falls back to nil → caller shows question mark
+-- 3.3.5 API note: IsInRaid/GetNumGroupMembers do NOT exist (added in 5.0.4).
+-- Use GetNumRaidMembers() > 0 to detect a raid group.
+-- Use GetNumRaidMembers() / GetNumPartyMembers() for iteration counts.
+
 local function GetPlayerClass(playerName)
     -- 1. Check cache first
     if classCache[playerName] then
@@ -71,10 +75,9 @@ local function GetPlayerClass(playerName)
 
     local classFileName
 
-    -- 2. Check raid roster
-    local inRaid = IsInRaid()
-    if inRaid then
-        for i = 1, GetNumGroupMembers() do
+    -- 2. Raid roster
+    if GetNumRaidMembers() > 0 then
+        for i = 1, GetNumRaidMembers() do
             local name, _, _, _, _, cls = GetRaidRosterInfo(i)
             if name == playerName then
                 classFileName = cls
@@ -82,13 +85,13 @@ local function GetPlayerClass(playerName)
             end
         end
     else
-        -- 3. Check party
+        -- 3. Party or solo — check self then party slots
         local name = UnitName("player")
         if name == playerName then
             local _, cls = UnitClass("player")
             classFileName = cls
         else
-            for i = 1, GetNumGroupMembers() - 1 do
+            for i = 1, GetNumPartyMembers() do
                 local unit = "party" .. i
                 if UnitName(unit) == playerName then
                     local _, cls = UnitClass(unit)
@@ -110,8 +113,8 @@ end
 -- Pre-populate class cache from current roster.
 -- Call this on raid/party changes and during Initialize.
 function UI:RefreshClassCache()
-    if IsInRaid() then
-        for i = 1, GetNumGroupMembers() do
+    if GetNumRaidMembers() > 0 then
+        for i = 1, GetNumRaidMembers() do
             local name, _, _, _, _, cls = GetRaidRosterInfo(i)
             if name and cls then
                 classCache[name] = cls
@@ -123,7 +126,7 @@ function UI:RefreshClassCache()
             local _, cls = UnitClass("player")
             classCache[name] = cls
         end
-        for i = 1, GetNumGroupMembers() - 1 do
+        for i = 1, GetNumPartyMembers() do
             local unit = "party" .. i
             local n = UnitName(unit)
             if n then
@@ -1328,20 +1331,39 @@ function UI:Refresh()
         frame.tabs.grouplot.text:SetText("Group: " .. totalGl)
 
     elseif currentTab == "master" then
-        local isML = LootyMasterLoot and LootyMasterLoot.isML
-        local items = isML and LootyMasterLoot.items or (LootyMasterLoot and LootyMasterLoot.remoteItems or {})
+        local isML   = LootyMasterLoot and LootyMasterLoot.isML
+        local role   = LootyMasterLoot and LootyMasterLoot.role
+        local items  = isML and LootyMasterLoot.items or (LootyMasterLoot and LootyMasterLoot.remoteItems or {})
         local mlCount = 0
         for _, item in pairs(items) do
             if not item.isDone then mlCount = mlCount + 1 end
         end
 
-        -- Show "Spectator Mode" indicator if not ML
-        if not isML and LootyMasterLoot and LootyMasterLoot.remoteMode then
-            local spectatorText = content:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-            spectatorText:SetPoint("TOPLEFT", content, "TOPLEFT", PANEL_PADDING, yOffset)
-            spectatorText:SetText("Spectating - ML: " .. (LootyMasterLoot.remoteML or "Unknown"))
-            spectatorText:SetTextColor(0.5, 0.5, 1.0)
+        -- ---- Role badge ----
+        -- Shown whenever master loot is active.
+        -- Loot method label (always shown in ML mode)
+        if LootyMasterLoot and LootyMasterLoot.isMasterLootActive then
+            local methodLabel = content:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+            methodLabel:SetPoint("TOPLEFT", content, "TOPLEFT", PANEL_PADDING, yOffset)
+            methodLabel:SetText("Loot: Master")
+            methodLabel:SetTextColor(0.7, 0.7, 0.7)
             yOffset = yOffset - 16
+        end
+
+        -- Role label (MasterLooter = gold, Raider = blue)
+        if role == "MasterLooter" then
+            local roleLabel = content:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+            roleLabel:SetPoint("TOPLEFT", content, "TOPLEFT", PANEL_PADDING, yOffset)
+            roleLabel:SetText("Role: MasterLooter")
+            roleLabel:SetTextColor(1.0, 0.82, 0.0)
+            yOffset = yOffset - 18
+
+        elseif role == "Raider" then
+            local roleLabel = content:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+            roleLabel:SetPoint("TOPLEFT", content, "TOPLEFT", PANEL_PADDING, yOffset)
+            roleLabel:SetText("Role: Raider")
+            roleLabel:SetTextColor(0.4, 0.7, 1.0)
+            yOffset = yOffset - 18
         end
 
         if mlCount > 0 then
@@ -1394,11 +1416,15 @@ function UI:Refresh()
             end
         end
 
-        if mlCount == 0 and (not LootyMasterLoot or #LootyMasterLoot.items == 0) then
+        if mlCount == 0 then
             local empty = content:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
             empty:SetPoint("TOP", content, "TOP", 0, -40)
-            if LootyMasterLoot and LootyMasterLoot.active then
-                empty:SetText("No items looted yet — open a corpse with loot")
+            if LootyMasterLoot and LootyMasterLoot.isMasterLootActive then
+                if role == "Raider" then
+                    empty:SetText("Waiting for MasterLooter to open a corpse...")
+                else
+                    empty:SetText("No items looted yet — open a corpse with loot")
+                end
             else
                 empty:SetText("Not in Master Loot mode")
             end

--- a/UI.lua
+++ b/UI.lua
@@ -1264,10 +1264,10 @@ end
 
 -- ---- Master Loot timer update ----
 
-function UI:UpdateMasterLootTimer(itemIndex, remaining)
+function UI:UpdateMasterLootTimer(itemKey, remaining)
     if not LootyFrame or not LootyFrame.content then return end
     for _, child in ipairs({ LootyFrame.content:GetChildren() }) do
-        if child._mlItemIndex == itemIndex and child._mlTimerBar and child._mlTimerBg then
+        if child._mlItemIndex == itemKey and child._mlTimerBar and child._mlTimerBg then
             local duration = child._mlDuration or LootyMasterLoot.rollDuration
             local pct = remaining / duration
             child._mlTimerBar:SetWidth(child._mlTimerBg:GetWidth() * pct)
@@ -1422,9 +1422,9 @@ function UI:Refresh()
         end
 
         if mlCount > 0 then
-            for i, item in pairs(items) do
+            for _, item in pairs(items) do
                 if not item.isDone then
-                    local panel, panelH = BuildMasterItemPanel(content, item, i, yOffset, { isML = isML })
+                    local panel, panelH = BuildMasterItemPanel(content, item, item.itemKey, yOffset, { isML = isML })
                     yOffset = yOffset - panelH - 4
                 end
             end
@@ -1472,8 +1472,8 @@ function UI:Refresh()
                 doneLabel:SetTextColor(0.4, 0.4, 0.4)
                 yOffset = yOffset - 16
 
-                for i, item in ipairs(doneItems) do
-                    local panel, panelH = BuildMasterItemPanel(content, item, i, yOffset, { isDone = true, isML = isML })
+                for _, item in ipairs(doneItems) do
+                    local panel, panelH = BuildMasterItemPanel(content, item, item.itemKey, yOffset, { isDone = true, isML = isML })
                     yOffset = yOffset - panelH - 4
                 end
             end

--- a/UI.lua
+++ b/UI.lua
@@ -929,11 +929,12 @@ function UI:ClearExpandedState(rollID)
 end
 
 -- ---- Build Master Loot item panel ----
--- opts: { isDone: bool }
+-- opts: { isDone: bool, isML: bool }
 
 local function BuildMasterItemPanel(content, item, itemIndex, yOffset, opts)
     opts = opts or {}
     local isDone = opts.isDone or false
+    local isML = opts.isML or false
     local alpha = isDone and 0.5 or 1.0
     local qColor = QUALITY_COLORS[item.quality] or QUALITY_COLORS[2]
 
@@ -1327,11 +1328,26 @@ function UI:Refresh()
         frame.tabs.grouplot.text:SetText("Group: " .. totalGl)
 
     elseif currentTab == "master" then
-        local mlCount = LootyMasterLoot and LootyMasterLoot:GetActiveItemCount() or 0
-        if mlCount > 0 and LootyMasterLoot then
-            for i, item in ipairs(LootyMasterLoot.items) do
+        local isML = LootyMasterLoot and LootyMasterLoot.isML
+        local items = isML and LootyMasterLoot.items or (LootyMasterLoot and LootyMasterLoot.remoteItems or {})
+        local mlCount = 0
+        for _, item in pairs(items) do
+            if not item.isDone then mlCount = mlCount + 1 end
+        end
+
+        -- Show "Spectator Mode" indicator if not ML
+        if not isML and LootyMasterLoot and LootyMasterLoot.remoteMode then
+            local spectatorText = content:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+            spectatorText:SetPoint("TOPLEFT", content, "TOPLEFT", PANEL_PADDING, yOffset)
+            spectatorText:SetText("Spectating - ML: " .. (LootyMasterLoot.remoteML or "Unknown"))
+            spectatorText:SetTextColor(0.5, 0.5, 1.0)
+            yOffset = yOffset - 16
+        end
+
+        if mlCount > 0 then
+            for i, item in pairs(items) do
                 if not item.isDone then
-                    local panel, panelH = BuildMasterItemPanel(content, item, i, yOffset)
+                    local panel, panelH = BuildMasterItemPanel(content, item, i, yOffset, { isML = isML })
                     yOffset = yOffset - panelH - 4
                 end
             end
@@ -1372,7 +1388,7 @@ function UI:Refresh()
                 yOffset = yOffset - 16
 
                 for i, item in ipairs(doneItems) do
-                    local panel, panelH = BuildMasterItemPanel(content, item, i, yOffset, { isDone = true })
+                    local panel, panelH = BuildMasterItemPanel(content, item, i, yOffset, { isDone = true, isML = isML })
                     yOffset = yOffset - panelH - 4
                 end
             end

--- a/UI.lua
+++ b/UI.lua
@@ -1124,9 +1124,48 @@ local function BuildMasterItemPanel(content, item, itemIndex, yOffset, opts)
         rollY = rollY - 24
     end
 
-    -- Roll list (if there are rolls) — individual rows with class icons
-    if item.rolling and rollCount > 0 then
-        -- Sort rolls by value desc
+    -- Roll button (for Raider when a roll is active)
+    -- RandomRoll(1, 100) is the 3.3.5 API for /roll 1 100.
+    -- It fires CHAT_MSG_SYSTEM, which Parser captures → RecordRoll (Raider path).
+    if not isML and item.rolling and not isDone then
+        local myName      = UnitName("player")
+        local alreadyRolled = item.rolls and item.rolls[myName] ~= nil
+        local btnY        = rollY - 4
+
+        local rollBtn = CreateFrame("Button", nil, panel)
+        rollBtn:SetSize(55, 20)
+        rollBtn:SetPoint("TOPLEFT", panel, "TOPLEFT", PANEL_PADDING, btnY)
+
+        if not alreadyRolled then
+            -- Active: green "Roll!" button
+            local rollBg = ColorTexture(rollBtn, "BACKGROUND", 0.15, 0.35, 0.15, 0.8)
+            rollBg:SetAllPoints(rollBtn)
+            local rollTxt = rollBtn:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+            rollTxt:SetPoint("CENTER", rollBtn, "CENTER", 0, 0)
+            rollTxt:SetText("Roll!")
+            rollTxt:SetTextColor(0.5, 1.0, 0.5)
+            rollBtn:SetScript("OnEnter", function() rollBg:SetVertexColor(0.25, 0.45, 0.25, 0.8) end)
+            rollBtn:SetScript("OnLeave", function() rollBg:SetVertexColor(0.15, 0.35, 0.15, 0.8) end)
+            rollBtn:SetScript("OnClick", function() RandomRoll(1, 100) end)
+        else
+            -- Already rolled: greyed out, non-interactive
+            local rolledBg = ColorTexture(rollBtn, "BACKGROUND", 0.15, 0.15, 0.15, 0.6)
+            rolledBg:SetAllPoints(rollBtn)
+            local rolledTxt = rollBtn:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+            rolledTxt:SetPoint("CENTER", rollBtn, "CENTER", 0, 0)
+            rolledTxt:SetText("Rolled")
+            rolledTxt:SetTextColor(0.4, 0.4, 0.4)
+            rollBtn:EnableMouse(false)
+        end
+
+        rollBtn:Show()
+        rollY = btnY - 22
+    end
+
+    -- Roll list — shown during active rolling (top 3) and in history (all rolls).
+    -- Was previously gated on item.rolling, which meant done items showed no rolls.
+    if rollCount > 0 then
+        -- Sort by value desc, then name asc for tie-breaking
         local sortedRolls = {}
         for playerName, rollInfo in pairs(item.rolls) do
             table.insert(sortedRolls, { name = playerName, value = rollInfo.value })
@@ -1136,10 +1175,13 @@ local function BuildMasterItemPanel(content, item, itemIndex, yOffset, opts)
             return a.name < b.name
         end)
 
-        local maxInline = math.min(3, #sortedRolls)
+        -- Live roll: cap at 3 (avoids panel growing unbounded during 25-man rolling).
+        -- History (not rolling): show all rolls so the full outcome is visible.
+        local maxRows = item.rolling and math.min(3, #sortedRolls) or #sortedRolls
         local rollRowH = 16
-        for i = 1, maxInline do
+        for i = 1, maxRows do
             local entry = sortedRolls[i]
+            local isWinner = (entry.name == item.winner)
             local classFile = GetPlayerClass(entry.name)
             local classTex = CLASS_TCOORDS[classFile]
 
@@ -1150,6 +1192,15 @@ local function BuildMasterItemPanel(content, item, itemIndex, yOffset, opts)
                 elseif not classTex then
                     DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00[LOOTY UI]|r class=" .. classFile .. " but NO coords")
                 end
+            end
+
+            -- Winner highlight background
+            if isWinner then
+                local winBg = ColorTexture(panel, "BACKGROUND",
+                    0.12, 0.60, 0.12, 0.25 * alpha)
+                winBg:SetPoint("TOPLEFT", panel, "TOPLEFT", 0, rollY)
+                winBg:SetPoint("TOPRIGHT", panel, "TOPRIGHT", 0, rollY)
+                winBg:SetHeight(rollRowH)
             end
 
             -- Class icon
@@ -1163,17 +1214,21 @@ local function BuildMasterItemPanel(content, item, itemIndex, yOffset, opts)
                 cIcon:SetTexture("Interface\\Icons\\INV_Misc_QuestionMark")
             end
 
-            -- Roll icon (need/greed/etc - default to need since MasterLoot is simple)
+            -- Dice icon
             local rIcon = panel:CreateTexture(nil, "ARTWORK")
             rIcon:SetSize(14, 14)
             rIcon:SetPoint("LEFT", cIcon, "RIGHT", 2, 0)
             rIcon:SetTexture("Interface\\Buttons\\UI-GroupLoot-Dice-Up")
 
-            -- Player name + value
+            -- Player name + value: winner in green, others in yellow
             local pName = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
             pName:SetPoint("LEFT", rIcon, "RIGHT", 3, 0)
-            pName:SetText(entry.name .. " (" .. entry.value .. ")")
-            pName:SetTextColor(1.0, 0.85, 0.2)
+            pName:SetText(entry.name .. " (" .. tostring(entry.value) .. ")")
+            if isWinner then
+                pName:SetTextColor(0.2 * alpha, 1.0 * alpha, 0.2 * alpha)
+            else
+                pName:SetTextColor(1.0 * alpha, 0.85 * alpha, 0.2 * alpha)
+            end
 
             rollY = rollY - rollRowH - 1
         end
@@ -1375,9 +1430,13 @@ function UI:Refresh()
             end
         end
 
-        -- Show done items with reduced opacity
+        -- Show done items with reduced opacity.
+        -- ML uses GetDoneItems() (self.items); Raider uses GetRemoteDoneItems() (remoteItems).
         if LootyMasterLoot then
-            local doneItems = LootyMasterLoot:GetDoneItems()
+            local doneItems = isML
+                and LootyMasterLoot:GetDoneItems()
+                or  LootyMasterLoot:GetRemoteDoneItems()
+
             if #doneItems > 0 then
                 local sepY = yOffset - 10
                 local sep = ColorTexture(content, "BORDER", 0.25, 0.25, 0.25, 0.4)
@@ -1386,7 +1445,7 @@ function UI:Refresh()
                 sep:SetHeight(1)
                 yOffset = sepY - 22
 
-                -- Clear Done button (at the TOP of done section)
+                -- Clear Done button — routes to the correct clear function by role
                 local clearBtn = CreateFrame("Button", nil, content)
                 clearBtn:SetSize(80, 20)
                 clearBtn:SetPoint("TOP", content, "TOP", 0, yOffset)
@@ -1399,7 +1458,11 @@ function UI:Refresh()
                 clearBtn:SetScript("OnEnter", function() clearBg:SetVertexColor(0.25, 0.25, 0.25, 0.8) end)
                 clearBtn:SetScript("OnLeave", function() clearBg:SetVertexColor(0.15, 0.15, 0.15, 0.8) end)
                 clearBtn:SetScript("OnClick", function()
-                    LootyMasterLoot:ClearDone()
+                    if isML then
+                        LootyMasterLoot:ClearDone()
+                    else
+                        LootyMasterLoot:ClearRemoteDone()
+                    end
                 end)
                 yOffset = yOffset - 24
 
@@ -1493,8 +1556,10 @@ function UI:UpdateTimers()
         end
     end
 
-    -- MasterLoot timer (update when on Master tab — visible timer)
-    if currentTab == "master" and LootyMasterLoot and LootyMasterLoot.currentRoll then
+    -- MasterLoot timer (update when on Master tab — visible timer).
+    -- Gate on active, not currentRoll: currentRoll is nil on the Raider client
+    -- (only the ML sets it), so the Raider's timer would never update otherwise.
+    if currentTab == "master" and LootyMasterLoot and LootyMasterLoot.active then
         for _, child in ipairs({ content:GetChildren() }) do
             if child._mlItemIndex and child._mlTimerBar and child._mlRollStart then
                 local elapsed = GetTime() - child._mlRollStart

--- a/openspec/changes/master-loot-sync/design.md
+++ b/openspec/changes/master-loot-sync/design.md
@@ -1,0 +1,305 @@
+# Design: Master Loot Multi-User Sync
+
+## Technical Approach
+
+Use WoW WOTLK 3.3.5 `SendAddonMessage` + `CHAT_MSG_ADDON` to broadcast Master Loot state changes from ML to all raid members. **ONE item per message** with 0.5s throttle between messages. **NO resync logic** — players sync automatically on next boss loot.
+
+---
+
+## Architecture Decisions
+
+### Decision 1: Communication Method
+
+| | |
+|---|---|
+| **Choice** | `SendAddonMessage` with "LOOTY" prefix |
+| **Alternatives** | Chat messages (RAID_WARNING), Guild info hacking |
+| **Rationale** | Native API designed for addon-to-addon communication. Messages are INVISIBLE to users. Available since WOTLK patch 1.12. 254 char limit manageable with single-item messages. |
+
+### Decision 2: Item Broadcasting (SIMPLIFIED)
+
+| | |
+|---|---|
+| **Choice** | ONE item per message, compacted: `ITEM\|index\|link\|texture\|quality\|name` |
+| **Alternatives** | Batch multiple items, fragment large messages |
+| **Rationale** | Simple 1:1 mapping (message = item). No fragmentation complexity. Item links ~70-80 chars + metadata fits easily in 254 char limit. 0.5s throttle prevents disconnect from rate limiting. |
+
+### Decision 3: NO Resync Logic
+
+| | |
+|---|---|
+| **Choice** | Remove resync completely |
+| **Alternatives** | RESYNC_REQ/RESYNC response, periodic full resync |
+| **Rationale** | In actual raids, people rarely join mid-boss. If someone gets replaced after a boss, addon detects Raider mode and syncs on NEXT boss loot. Less code = fewer bugs, better performance. KISS principle. |
+
+### Decision 4: Message Serialization
+
+| | |
+|---|---|
+| **Choice** | Compact pipe-delimited format with escaped pipes |
+| **Format** | `ITEM\|index\|link\|texture\|quality\|name` |
+| **Rationale** | All critical item data in one message. Receiver can reconstruct item object. Escape `\|\|` for pipes inside links. |
+
+### Decision 5: Prefix Filtering (WOTLK 3.3.5 specific)
+
+| | |
+|---|---|
+| **Choice** | Manual prefix check in `CHAT_MSG_ADDON` handler |
+| **Alternatives** | `RegisterAddonMessagePrefix` (doesn't exist in 3.3.5) |
+| **Rationale** | `RegisterAddonMessagePrefix()` was added in Cataclysm 4.1.0. In 3.3.5, ALL addon messages go to ALL addons. Must check `prefix == "LOOTY"` manually. |
+
+---
+
+## Data Flow
+
+```
+[Master Looter Client]                    [Raid Member Clients]
+        │                                        │
+        ├─ LOOT_OPENED                         │
+        │   └─ For each item (0.5s apart):     │
+        │       SendAddonMessage(              │
+        │         "LOOTY",                     │
+        │         "ITEM|idx|link|tex|q|name") │
+        │            ────────────────────────→  CHAT_MSG_ADDON
+        │                                        ├─ Parse "ITEM|..."
+        │                                        ├─ Deserialize item
+        │                                        ├─ Add to remoteItems[]
+        │                                        └─ Refresh UI
+        │                                        │
+        ├─ StartRoll(itemIndex)                │
+        │   └─ Send "ROLL_START|index"        │
+        │            ────────────────────────→  Show rolling UI
+        │                                        │
+        ├─ Player rolls /roll                  │
+        │   └─ CHAT_MSG_SYSTEM caught         │
+        │       by ML → RecordRoll()           │
+        │       (No sync needed - all see /roll)│
+        │                                        │
+        ├─ EndRoll(itemIndex)                 │
+        │   └─ Send "ROLL_END|idx|winner"    │
+        │            ────────────────────────→  Show winner
+        │                                        │
+        └─ ToggleDone(itemIndex)              │
+           └─ Send "ITEM_DONE|index"          │
+                  ────────────────────────→  Mark as done
+```
+
+---
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `Core.lua` | Modify | Register `CHAT_MSG_ADDON` event, delegate to `LootyMasterLoot:OnAddonMessage()` |
+| `MasterLoot.lua` | Modify | Add: `remoteItems{}`, `remoteML`, `SendThrottledMessage()`, `SerializeItem()`, `DeserializeItem()`, `OnAddonMessage()` parser |
+| `UI.lua` | Modify | Show `remoteItems` for non-ML, disable buttons, show "Spectator - ML: Name" indicator |
+
+---
+
+## Interfaces / Contracts
+
+### Addon Message Protocol (Prefix: "LOOTY")
+
+```
+ITEM|index|itemLink|texture|quality|name
+  → Sent when ML opens loot, ONE per item with 0.5s delay
+  → index: number (loot slot index)
+  → itemLink: full itemLink string
+  → texture: icon path (e.g., "Interface\\Icons\\INV_Sword_01")
+  → quality: number 0-7
+  → name: item name (for fallback if link parse fails)
+
+ROLL_START|index
+  → Sent when ML starts a roll for an item
+  → index: number (index in items/remoteItems)
+
+ROLL_END|index|winnerName
+  → Sent when ML ends roll and announces winner
+  → winnerName: string
+
+ITEM_DONE|index
+  → Sent when ML marks item as done
+  → index: number
+
+CLEAR
+  → Sent when ML switches loot method off or clears all
+  → No payload
+```
+
+### Compact Item Serialization (ML side)
+
+```lua
+function MasterLoot:SerializeItem(item, index)
+    -- Compact format: ITEM|index|link|texture|quality|name
+    -- Escape pipe characters in link (safety measure)
+    local link = string.gsub(item.link or "", "|", "||")
+    local texture = item.texture or ""
+    local quality = tostring(item.quality or 2)
+    local name = item.name or "Unknown"
+    
+    return string.format("ITEM|%d|%s|%s|%s|%s", 
+        index, link, texture, quality, name)
+end
+```
+
+### Item Deserialization (Receiver side)
+
+```lua
+function MasterLoot:DeserializeItem(message)
+    -- Parse: ITEM|index|link|texture|quality|name
+    -- Link may contain escaped pipes (||), need to handle carefully
+    local header, rest = string.match(message, "^ITEM|(.+)$")
+    if not header then return nil end
+    
+    -- Split by | but respect escaped ||
+    local parts = {}
+    local current = ""
+    local i = 1
+    while i <= #rest do
+        local char = string.sub(rest, i, i)
+        if char == "|" and i < #rest and string.sub(rest, i+1, i+1) == "|" then
+            current = current .. "|"
+            i = i + 2
+        elseif char == "|" then
+            table.insert(parts, current)
+            current = ""
+            i = i + 1
+        else
+            current = current .. char
+            i = i + 1
+        end
+    end
+    table.insert(parts, current)  -- Last part
+    
+    if #parts < 5 then return nil end
+    
+    return {
+        index = tonumber(parts[1]),
+        link = string.gsub(parts[2], "||", "|"),  -- Unescape
+        texture = parts[3],
+        quality = tonumber(parts[4]) or 2,
+        name = parts[5],
+    }
+end
+```
+
+### State Structures
+
+```lua
+-- In MasterLoot.lua
+
+-- Master Looter's local state (existing)
+MasterLoot.items = {
+    [1] = {
+        slot = number,
+        name = string,
+        link = string,
+        texture = string,
+        quantity = number,
+        quality = number,
+        rolls = { [playerName] = { value = number, time = number } },
+        rerolls = { [playerName] = { value = number, time = number } },
+        rolling = boolean,
+        rollStart = number or nil,
+        isDone = boolean,
+        winner = string or nil,
+    },
+    -- ...
+}
+
+-- Remote state (for non-ML clients) - NEW
+MasterLoot.remoteMode = false      -- Are we in remote spectator mode?
+MasterLoot.remoteItems = {}       -- Mirror of ML's items (indexed by index)
+MasterLoot.remoteML = nil         -- Name of ML we're tracking
+MasterLoot.isML = false          -- Is player the ML? (existing)
+
+-- Throttle for sending messages (rate limit protection) - NEW
+MasterLoot.msgThrottle = 0.5     -- Min seconds between auto-messages
+MasterLoot.lastMsgTime = 0
+MasterLoot.pendingItems = {}      -- Queue for items waiting to be sent
+MasterLoot.sendTimer = nil        -- Timer frame for throttled sending
+```
+
+### Throttled Sending (ML side)
+
+```lua
+function MasterLoot:SendThrottledMessage(msg)
+    -- Add to queue
+    table.insert(self.pendingItems, msg)
+    self:ProcessSendQueue()
+end
+
+function MasterLoot:ProcessSendQueue()
+    if #self.pendingItems == 0 then return end
+    if GetTime() - self.lastMsgTime < self.msgThrottle then
+        -- Schedule timer to try again
+        if not self.sendTimer then
+            self.sendTimer = CreateFrame("Frame")
+            self.sendTimer:SetScript("OnUpdate", function(self)
+                MasterLoot:ProcessSendQueue()
+            end)
+        end
+        self.sendTimer:Show()
+        return
+    end
+    
+    -- Send next message
+    local msg = table.remove(self.pendingItems, 1)
+    SendAddonMessage("LOOTY", msg, "RAID")
+    self.lastMsgTime = GetTime()
+    
+    -- If more items, will be picked up on next OnUpdate
+    if #self.pendingItems == 0 and self.sendTimer then
+        self.sendTimer:Hide()
+    end
+end
+```
+
+### UI Contract (for remote mode)
+
+```lua
+-- In UI.lua
+-- When rendering Master Loot tab for non-ML:
+local isML = LootyMasterLoot.isML
+local items = isML and LootyMasterLoot.items or LootyMasterLoot.remoteItems
+
+-- Show "Spectator Mode" indicator if not ML
+if not isML and LootyMasterLoot.remoteMode then
+    -- Display: "Spectating - ML: " .. LootyMasterLoot.remoteML
+    -- Disable all action buttons (Start Roll, Done, End Roll, Cancel)
+end
+```
+
+---
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Message parsing (`OnAddonMessage`) | Create test cases with mock messages, verify state changes |
+| Unit | Item serialization/deserialization | Test compact format parse with various item links |
+| Unit | Throttle mechanism | Verify 0.5s delay between messages |
+| Integration | Full sync flow (ML → remote) | Simulate `CHAT_MSG_ADDON` events, verify `remoteItems` |
+| Manual | Real raid scenario | Have 2 clients, ML opens loot, verify other sees items |
+
+---
+
+## Migration / Rollout
+
+No migration required. This is a new feature.
+
+- Non-ML clients with old version: won't receive sync (expected)
+- ML with new version + old clients: old clients won't see items (expected)
+- Both sides updated: full sync works
+
+---
+
+## Open Questions
+
+- [x] ~~Resync logic needed?~~ → **REMOVED**. Not needed per user's reasoning.
+- [ ] Should we show a "Player X is using outdated Looty" warning? → **DECISION: NO**, overcomplicates.
+- [ ] What happens if ML changes mid-raid? → Clear remote state on `PARTY_LOOT_METHOD_CHANGED`.
+
+---
+
+**Next Step**: Ready for `sdd-tasks` (break down into implementable tasks).

--- a/openspec/changes/master-loot-sync/tasks.md
+++ b/openspec/changes/master-loot-sync/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: Master Loot Multi-User Sync
+
+## Phase 1: Foundation
+
+- [x] 1.1 In `Core.lua`: Register `CHAT_MSG_ADDON` event in `PLAYER_LOGIN`
+- [x] 1.2 In `Core.lua`: Add `CHAT_MSG_ADDON` handler, delegate to `LootyMasterLoot:OnAddonMessage()`
+- [x] 1.3 In `MasterLoot.lua`: Add state vars (`remoteMode`, `remoteItems{}`, `remoteML`, `msgThrottle`, `lastMsgTime`, `pendingItems{}`, `sendTimer`)
+
+## Phase 2: Message Sending (ML side)
+
+- [x] 2.1 In `MasterLoot.lua`: Implement `SendThrottledMessage()` with 0.5s queue
+- [x] 2.2 In `MasterLoot.lua`: Implement `SerializeItem()` → `"ITEM|index|link|texture|quality|name"`
+- [x] 2.3 In `MasterLoot.lua`: Modify `OnLootOpened()` to send items via `SendThrottledMessage()` (one per 0.5s)
+- [x] 2.4 In `MasterLoot.lua`: Send `"ROLL_START|index"` in `StartRoll()`
+- [x] 2.5 In `MasterLoot.lua`: Send `"ROLL_END|index|winner"` in `EndRoll()`
+- [x] 2.6 In `MasterLoot.lua`: Send `"ITEM_DONE|index"` in `ToggleDone()`
+- [x] 2.7 In `MasterLoot.lua`: Send `"CLEAR"` in `OnLootMethodChanged()` when deactivating
+
+## Phase 3: Message Receiving (All clients)
+
+- [x] 3.1 In `MasterLoot.lua`: Implement `DeserializeItem()` to parse `"ITEM|index|link|texture|quality|name"`
+- [x] 3.2 In `MasterLoot.lua`: Implement `OnAddonMessage(prefix, message, distribution, sender)`
+- [x] 3.3 In `MasterLoot.lua`: Parse `ITEM` messages → populate `remoteItems{}`
+- [x] 3.4 In `MasterLoot.lua`: Parse `ROLL_START` → set remote item `rolling=true`
+- [x] 3.5 In `MasterLoot.lua`: Parse `ROLL_END` → set remote item `winner`, `rolling=false`
+- [x] 3.6 In `MasterLoot.lua`: Parse `ITEM_DONE` → set remote item `isDone=true`
+- [x] 3.7 In `MasterLoot.lua`: Parse `CLEAR` → wipe `remoteItems{}`
+- [x] 3.8 In `MasterLoot.lua`: Set `remoteMode=true`, `remoteML=sender` on first `ITEM` received
+
+## Phase 4: UI Integration
+
+- [x] 4.1 In `UI.lua`: Modify Master Loot tab to use `remoteItems{}` when not ML
+- [x] 4.2 In `UI.lua`: Disable all action buttons (Start Roll, Done, End Roll) for `remoteMode`
+- [x] 4.3 In `UI.lua`: Add `"Spectator - ML: [Name]"` indicator when `remoteMode=true`
+- [x] 4.4 In `UI.lua`: Refresh UI on `CHAT_MSG_ADDON` (through `MasterLoot:OnAddonMessage()` calling `LootyUI:Refresh()`)
+
+## Phase 5: Cleanup
+
+- [x] 5.1 In `MasterLoot.lua`: Clear `remoteItems` on `PARTY_LOOT_METHOD_CHANGED` if not ML
+- [x] 5.2 Add comments explaining throttle logic and message protocol
+- [x] 5.3 Test: Inject test data for remote mode (`/looty mtestremote`)
+
+---
+
+## Implementation Order
+
+**Phase 1** (Foundation) → **Phase 2** (ML sends) → **Phase 3** (All receive) → **Phase 4** (UI) → **Phase 5** (Cleanup)
+
+---
+
+**Next Step**: Ready for `sdd-apply` (implement tasks).

--- a/todos
+++ b/todos
@@ -1,0 +1,11 @@
+TODOS: 
+
+1:  Find information on, Loot functions -> https://web.archive.org/web/20100726112636/http://wowprogramming.com/docs/api_categories#loot
+	An idea is, perhaps we can create our own Roll by Blizzard commands instead of parsing the loot messages. This will keep MasterLoot on, but we open the roll and let blizzard do the dice and results.
+	(Needs investigation)
+
+
+
+- GiveMasterLoot(slot, index) -> Awards Item to a group member (No effect if not MasterLoot)
+
+


### PR DESCRIPTION
- Add CHAT_MSG_ADDON handler for LOOTY prefix (WoW 3.3.5)
- Implement one-item-per-message sync with 0.5s throttle queue
- Serialize/Deserialize items: ITEM|index|link|texture|quality|name
- Parse commands: ROLL_START, ROLL_END, ITEM_DONE, CLEAR
- Remote mode for non-ML clients: remoteItems{}, spectator UI
- Disable action buttons when not ML, show 'Spectating - ML: Name'
- Add /looty mtestremote command for testing remote mode
- No resync logic (players sync on next boss loot)


Closes #1 