### PR TITLE
fix: prevent frame accumulation stack overflow in Group and Master Loot

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -145,9 +145,9 @@ function addon:CHAT_MSG_SYSTEM(event, message)
 end
 
 function addon:CHAT_MSG_ADDON(event, prefix, message, distribution, sender)
-    if self.db and self.db.debug then
-        addon:Print(string.format("[ADDON] prefix=%s dist=%s sender=%s msg=%.40s",
-            tostring(prefix), tostring(distribution), tostring(sender), tostring(message)))
+    if self.db and self.db.debug and prefix == "LOOTY" then
+        addon:Print(string.format("[ADDON] prefix=%s event=%s dist=%s sender=%s msg=%.40s",
+            tostring(prefix), tostring(event), tostring(distribution), tostring(sender), tostring(message)))
     end
     if prefix ~= "LOOTY" then return end
     LootyMasterLoot:OnAddonMessage(prefix, message, distribution, sender)

--- a/GroupLoot.lua
+++ b/GroupLoot.lua
@@ -109,6 +109,38 @@ LootyLootRoll = LootRoll
 local GroupLoot = {}
 LootyGroupLoot = GroupLoot
 
+-- Safety net: poll completed rolls in case chat messages are missed.
+-- WoW 3.3.5 has no event for "roll timer expired" — we detect it by
+-- checking if WoW no longer knows about the roll via GetLootRollItemInfo.
+local safetyFrame = CreateFrame("Frame")
+safetyFrame:Hide()
+safetyFrame.elapsed = 0
+safetyFrame:SetScript("OnUpdate", function(self, elapsed)
+    self.elapsed = self.elapsed + elapsed
+    if self.elapsed < 3 then return end  -- poll every 3 seconds
+    self.elapsed = 0
+
+    for rollID, roll in pairs(GroupLoot.activeRolls) do
+        if roll.completed and not roll._safetyChecked then
+            -- If WoW no longer knows about this roll, the timer expired
+            -- and the chat message was likely missed.
+            local texture = GetLootRollItemInfo(rollID)
+            if not texture then
+                roll._safetyChecked = true
+                if Looty.db and Looty.db.debug then
+                    Looty:Print("[GroupLoot] Safety net: finalizing roll " .. rollID .. " (" .. roll.name .. ")")
+                end
+                local winner = roll:DetermineWinner()
+                roll.winner = winner
+                GroupLoot:FinalizeRoll(rollID)
+            end
+        end
+    end
+
+    -- Stop polling if no active rolls remain
+    if not next(GroupLoot.activeRolls) then self:Hide() end
+end)
+
 -- Active rolls keyed by rollID (numeric, from WoW API)
 GroupLoot.activeRolls = {}
 
@@ -141,10 +173,13 @@ function GroupLoot:StartRoll(rollID, duration)
           canNeed, canGreed, canDisenchant = GetLootRollItemInfo(rollID)
     if not name then return end
 
+    -- Convert milliseconds to seconds (WoW 3.3.5 API passes ms)
+    local durationSec = (duration or 90000) / 1000
+
     local link = GetLootRollItemLink(rollID)
     self.activeRolls[rollID] = LootRoll.new(
         rollID, name, link, texture, count, quality,
-        bindOnPickUp, canNeed, canGreed, canDisenchant, duration
+        bindOnPickUp, canNeed, canGreed, canDisenchant, durationSec
     )
 
     Looty:Print("New roll: " .. name)
@@ -163,6 +198,7 @@ function GroupLoot:MarkCompleted(rollID)
     local roll = self.activeRolls[rollID]
     if roll then
         roll.completed = true
+        safetyFrame:Show()  -- start safety net polling
         LootyUI:Refresh()
     end
 end
@@ -171,6 +207,9 @@ end
 function GroupLoot:FinalizeRoll(rollID)
     local roll = self.activeRolls[rollID]
     if not roll then return end
+
+    -- Cancel safety net check for this roll (chat was received)
+    if roll then roll._safetyChecked = true end
 
     if LootyUI and LootyUI.ClearExpandedState then
         LootyUI:ClearExpandedState(rollID)
@@ -203,7 +242,7 @@ function GroupLoot:RecordChoice(rollID, playerName, rollType, value)
             Looty:Print(string.format("[GroupLoot] RecordChoice OK — %s type=%s val=%s on %s",
                 playerName, rollType, tostring(value), roll.name))
         end
-        LootyUI:Refresh()
+        -- Don't refresh — let timer update naturally, avoids timer bar flicker
     end
     return ok
 end

--- a/Looty.toc
+++ b/Looty.toc
@@ -2,7 +2,7 @@
 ## Title: Looty
 ## Notes: Tracks group loot and master loot rolls in a compact window.
 ## Author: Ravelo
-## Version: 2.1.0
+## Version: 2.1.1
 ## SavedVariables: Looty_SavedVars
 
 ## Load order:

--- a/MasterLoot.lua
+++ b/MasterLoot.lua
@@ -811,11 +811,8 @@ function MasterLoot:CreateTimer(itemKey)
             local remaining = MasterLoot.rollDuration - (GetTime() - item.rollStart)
             if remaining <= 0 then
                 MasterLoot:EndRoll(self.itemKey)
-            else
-                if LootyUI and LootyUI.UpdateMasterLootTimer then
-                    LootyUI:UpdateMasterLootTimer(self.itemKey, remaining)
-                end
             end
+            -- Timer bar updates handled by global UpdateTimers (250ms tick)
         else
             self:Hide()
         end

--- a/Parser.lua
+++ b/Parser.lua
@@ -106,6 +106,20 @@ function Parser:ProcessMessage(message)
         Looty:Print("[PARSE] " .. message)
     end
 
+    -- 0. "Everyone passed on [Item]" — special case, no real player
+    local everyoneItem = string.match(message, "^Everyone passed on%s*:?%s*(.+)$")
+                     or string.match(message, "^Everyone automatically passed on%s*:?%s*(.+)$")
+    if everyoneItem then
+        if Looty.db and Looty.db.debug then
+            Looty:Print("[PARSE] EVERYONE PASSED: " .. everyoneItem)
+        end
+        local rollID = FindRollByItem(everyoneItem)
+        if rollID then
+            LootyGroupLoot:FinalizeRoll(rollID)
+        end
+        return
+    end
+
     -- 1. Roll result (type + value + item + player)
     local rollType, value, itemName, playerName = self:ParseRollResult(message)
     if rollType and value and playerName then

--- a/UI/Frame.lua
+++ b/UI/Frame.lua
@@ -340,15 +340,10 @@ function UI:UpdateTimers()
     local content = frame.content
 
     if currentTab == "grouplot" then
-        UpdateGroupLootTimers(content)
+        UpdateGroupLootTimers()
     elseif currentTab == "master" then
-        UpdateMasterLootTimers(content)
+        UpdateMasterLootTimers()
     end
-end
-
--- Called from MasterLoot.CreateTimer callback
-function UI:UpdateMasterLootTimer(itemKey, remaining)
-    LootyUpdateMasterLootTimer(itemKey, remaining)
 end
 
 -- ============================================================

--- a/UI/GroupLootUI.lua
+++ b/UI/GroupLootUI.lua
@@ -266,9 +266,15 @@ function BuildRollPanel(panel, rollData, yOffset, opts)
     -- Item header — returns y start for the cursor
     local layout = LootyVLayout(panel, LootyMakeItemHeader(panel, rollData, iconH, alpha), 0)
 
-    -- Timer bar (active rolls only)
+    -- Timer bar (active rolls only — preserve existing bar across refreshes)
     if not isHistory and not rollData.completed then
-        LootyMakeTimerBar(panel, layout, rollData.duration, rollData.startTime, "_gl", rollData.rollID)
+        if not panel._glTimerBar then
+            LootyMakeTimerBar(panel, layout, rollData.duration, rollData.startTime, "_gl", rollData.rollID)
+        else
+            -- Timer already exists — just advance layout past it
+            local barH = 5
+            layout:Advance(barH + 4)
+        end
     end
 
     -- Winner banner
@@ -383,6 +389,11 @@ function UpdateGroupLootTimers()
         if panel:IsShown() and panel._glTimerBar and panel._glRollStart then
             local elapsed   = GetTime() - panel._glRollStart
             local remaining = math.max(0, panel._glDuration - elapsed)
+            -- Debug: catch invalid state
+            if remaining > 9999 and Looty and Looty.db and Looty.db.debug then
+                Looty:Print(string.format("[TimerDebug] rollID=%s elapsed=%.1f remaining=%.1f duration=%.1f rollStart=%.1f getTime=%.1f",
+                    tostring(panel._glRollID), elapsed, remaining, panel._glDuration or 0, panel._glRollStart or 0, GetTime()))
+            end
             local pct       = remaining / panel._glDuration
 
             panel._glTimerBar:SetWidth(panel._glTimerBg:GetWidth() * pct)

--- a/UI/GroupLootUI.lua
+++ b/UI/GroupLootUI.lua
@@ -16,6 +16,61 @@ local ROLL_SECTIONS = { "need", "greed", "disenchant", "pass" }
 local expandedSections = {}
 
 -- ============================================================
+-- ---- Frame pool ----
+-- ============================================================
+-- Panels keyed by rollID. Prevents frame accumulation on content.
+-- In WoW, frames cannot be destroyed — we hide and reparent them
+-- instead of letting them pile up as children of content.
+
+local panelPool = {}  -- { [rollID] = panelFrame }
+
+-- Reset a reused panel: clear all children, regions, and custom fields.
+local function ResetPanel(panel)
+    for _, child in ipairs({ panel:GetChildren() }) do
+        child:Hide(); child:ClearAllPoints()
+    end
+    for _, region in ipairs({ panel:GetRegions() }) do
+        region:Hide()
+    end
+    panel._glTimerBg   = nil
+    panel._glTimerBar  = nil
+    panel._glTimerText = nil
+    panel._glRollStart = nil
+    panel._glDuration  = nil
+    panel._glRollID    = nil
+    panel._expandedType = nil
+    panel:SetScript("OnEnter", nil)
+    panel:SetScript("OnLeave", nil)
+    panel:SetScript("OnMouseUp", nil)
+end
+
+-- Acquire a panel for a rollID. Returns an existing (reset) or new panel.
+local function AcquirePanel(rollID, content)
+    local panel = panelPool[rollID]
+    if panel then
+        ResetPanel(panel)
+        panel:SetParent(content)
+    else
+        panel = CreateFrame("Frame", nil, content)
+        panelPool[rollID] = panel
+    end
+    panel:Show()
+    return panel
+end
+
+-- Release panels not in the current active set.
+-- Hides them and removes from content's child hierarchy.
+local function ReleaseUnused(activeKeys)
+    for rollID, panel in pairs(panelPool) do
+        if not activeKeys[rollID] then
+            panel:Hide()
+            panel:ClearAllPoints()
+            panel:SetParent(nil)
+        end
+    end
+end
+
+-- ============================================================
 -- ---- Roll panel internals ----
 -- ============================================================
 
@@ -183,18 +238,30 @@ end
 -- ---- BuildRollPanel ----
 -- ============================================================
 
--- Builds a single roll card.
+-- Builds a single roll card into a pre-acquired panel.
 -- opts: { isHistory = bool }
 -- Returns: panel frame, total panel height.
-function BuildRollPanel(content, rollData, yOffset, opts)
+function BuildRollPanel(panel, rollData, yOffset, opts)
     opts = opts or {}
     local isHistory    = opts.isHistory or false
     local iconH        = isHistory and 28 or (LOOTY_ICON_SIZE - 4)
     local alpha        = isHistory and 0.6 or 1.0
-    local contentWidth = content:GetWidth()
+    local contentWidth = panel:GetParent():GetWidth()
 
-    local panel  = LootyMakePanel(content, isHistory and 0.3 or 0.6)
     panel:SetWidth(contentWidth)
+
+    -- Background + border (LootyMakePanel inline — panel is pre-acquired)
+    LootyColorTex(panel, "BACKGROUND", 0.12, 0.12, 0.12, isHistory and 0.2 or 0.6):SetAllPoints(panel)
+    local function border(pt1, pt2, isH)
+        local t = LootyColorTex(panel, "BORDER", 0.20, 0.20, 0.20, 0.5)
+        t:SetPoint(pt1, panel, pt1, 0, 0)
+        t:SetPoint(pt2, panel, pt2, 0, 0)
+        if isH then t:SetHeight(1) else t:SetWidth(1) end
+    end
+    border("TOPLEFT",    "TOPRIGHT",    true)
+    border("BOTTOMLEFT", "BOTTOMRIGHT", true)
+    border("TOPLEFT",    "BOTTOMLEFT",  false)
+    border("TOPRIGHT",   "BOTTOMRIGHT", false)
 
     -- Item header — returns y start for the cursor
     local layout = LootyVLayout(panel, LootyMakeItemHeader(panel, rollData, iconH, alpha), 0)
@@ -228,8 +295,8 @@ function BuildRollPanel(content, rollData, yOffset, opts)
     local totalH = -layout.y + LOOTY_PANEL_PADDING
     panel:SetHeight(totalH)
 
-    panel:SetPoint("TOPLEFT",  content, "TOPLEFT",  0, yOffset)
-    panel:SetPoint("TOPRIGHT", content, "TOPRIGHT", 0, yOffset)
+    panel:SetPoint("TOPLEFT",  panel:GetParent(), "TOPLEFT",  0, yOffset)
+    panel:SetPoint("TOPRIGHT", panel:GetParent(), "TOPRIGHT", 0, yOffset)
 
     return panel, totalH
 end
@@ -247,9 +314,14 @@ function RefreshGroupLootTab(content, frame)
     local activeRolls    = LootyGroupLoot:GetAllActiveRolls()
     local completedRolls = LootyGroupLoot:GetCompletedRolls()
 
+    -- Track which panels are currently needed
+    local activeKeys = {}
+
     -- Active rolls
     for _, rollData in ipairs(activeRolls) do
-        local _, h = BuildRollPanel(content, rollData, yOffset, { isHistory = false })
+        activeKeys[rollData.rollID] = true
+        local panel = AcquirePanel(rollData.rollID, content)
+        local _, h = BuildRollPanel(panel, rollData, yOffset, { isHistory = false })
         yOffset = yOffset - h - 6
     end
 
@@ -276,7 +348,9 @@ function RefreshGroupLootTab(content, frame)
         yOffset = yOffset - lblH
 
         for _, rollData in ipairs(completedRolls) do
-            local _, h = BuildRollPanel(content, rollData, yOffset, { isHistory = true })
+            activeKeys[rollData.rollID] = true
+            local panel = AcquirePanel(rollData.rollID, content)
+            local _, h = BuildRollPanel(panel, rollData, yOffset, { isHistory = true })
             yOffset = yOffset - h - 4
         end
     end
@@ -294,6 +368,9 @@ function RefreshGroupLootTab(content, frame)
         frame.tabs.grouplot.text:SetText("Group: " .. total)
     end
 
+    -- Release panels no longer in use
+    ReleaseUnused(activeKeys)
+
     return yOffset
 end
 
@@ -301,25 +378,25 @@ end
 -- ---- Timer update (called from UpdateTimers) ----
 -- ============================================================
 
-function UpdateGroupLootTimers(content)
-    for _, child in ipairs({ content:GetChildren() }) do
-        if child._glTimerBar and child._glRollStart then
-            local elapsed   = GetTime() - child._glRollStart
-            local remaining = math.max(0, child._glDuration - elapsed)
-            local pct       = remaining / child._glDuration
+function UpdateGroupLootTimers()
+    for _, panel in pairs(panelPool) do
+        if panel:IsShown() and panel._glTimerBar and panel._glRollStart then
+            local elapsed   = GetTime() - panel._glRollStart
+            local remaining = math.max(0, panel._glDuration - elapsed)
+            local pct       = remaining / panel._glDuration
 
-            child._glTimerBar:SetWidth(child._glTimerBg:GetWidth() * pct)
+            panel._glTimerBar:SetWidth(panel._glTimerBg:GetWidth() * pct)
 
             if pct < 0.25 then
-                child._glTimerBar:SetVertexColor(0.9, 0.2, 0.15, 0.8)
+                panel._glTimerBar:SetVertexColor(0.9, 0.2, 0.15, 0.8)
             elseif pct < 0.5 then
-                child._glTimerBar:SetVertexColor(0.9, 0.7, 0.1, 0.8)
+                panel._glTimerBar:SetVertexColor(0.9, 0.7, 0.1, 0.8)
             else
-                child._glTimerBar:SetVertexColor(0.4, 0.4, 0.4, 0.8)
+                panel._glTimerBar:SetVertexColor(0.4, 0.4, 0.4, 0.8)
             end
 
-            if child._glTimerText then
-                child._glTimerText:SetText(string.format("%d:%02d",
+            if panel._glTimerText then
+                panel._glTimerText:SetText(string.format("%d:%02d",
                     math.floor(remaining / 60), math.floor(remaining % 60)))
             end
         end

--- a/UI/MasterLootUI.lua
+++ b/UI/MasterLootUI.lua
@@ -6,6 +6,54 @@
 -- MasterLootUI references Looty globally at call time (never at load time)
 
 -- ============================================================
+-- ---- Frame pool ----
+-- ============================================================
+-- Panels keyed by itemKey. Prevents frame accumulation on content.
+
+local panelPool = {}  -- { [itemKey] = panelFrame }
+
+-- Reset a reused panel: clear all children, regions, and custom fields.
+local function ResetPanel(panel)
+    for _, child in ipairs({ panel:GetChildren() }) do
+        child:Hide(); child:ClearAllPoints()
+    end
+    for _, region in ipairs({ panel:GetRegions() }) do
+        region:Hide()
+    end
+    panel._mlTimerBg   = nil
+    panel._mlTimerBar  = nil
+    panel._mlTimerText = nil
+    panel._mlRollStart = nil
+    panel._mlDuration  = nil
+    panel._mlItemKey   = nil
+end
+
+-- Acquire a panel for an itemKey. Returns an existing (reset) or new panel.
+local function AcquirePanel(itemKey, content)
+    local panel = panelPool[itemKey]
+    if panel then
+        ResetPanel(panel)
+        panel:SetParent(content)
+    else
+        panel = CreateFrame("Frame", nil, content)
+        panelPool[itemKey] = panel
+    end
+    panel:Show()
+    return panel
+end
+
+-- Release panels not in the current active set.
+local function ReleaseUnused(activeKeys)
+    for itemKey, panel in pairs(panelPool) do
+        if not activeKeys[itemKey] then
+            panel:Hide()
+            panel:ClearAllPoints()
+            panel:SetParent(nil)
+        end
+    end
+end
+
+-- ============================================================
 -- ---- Determine what action buttons a player can take ----
 -- ============================================================
 -- Returns one of:
@@ -206,18 +254,31 @@ end
 -- ---- BuildMasterItemPanel ----
 -- ============================================================
 
--- Builds one item card for the Master tab.
+-- Builds one item card into a pre-acquired panel.
 -- opts: { isDone = bool, isML = bool }
 -- Returns: panel frame, total height.
-function BuildMasterItemPanel(content, item, itemKey, yOffset, opts)
+function BuildMasterItemPanel(panel, item, itemKey, yOffset, opts)
     opts = opts or {}
     local isDone = opts.isDone or item:IsDone()
     local isML   = opts.isML   or LootyMasterLoot:IsML()
     local alpha  = isDone and 0.5 or 1.0
     local iconH  = LOOTY_ICON_SIZE - 4
+    local contentWidth = panel:GetParent():GetWidth()
 
-    local panel  = LootyMakePanel(content, isDone and 0.2 or 0.6)
-    panel:SetWidth(content:GetWidth())
+    panel:SetWidth(contentWidth)
+
+    -- Background + border (LootyMakePanel inline)
+    LootyColorTex(panel, "BACKGROUND", 0.12, 0.12, 0.12, isDone and 0.2 or 0.6):SetAllPoints(panel)
+    local function border(pt1, pt2, isH)
+        local t = LootyColorTex(panel, "BORDER", 0.20, 0.20, 0.20, 0.5)
+        t:SetPoint(pt1, panel, pt1, 0, 0)
+        t:SetPoint(pt2, panel, pt2, 0, 0)
+        if isH then t:SetHeight(1) else t:SetWidth(1) end
+    end
+    border("TOPLEFT",    "TOPRIGHT",    true)
+    border("BOTTOMLEFT", "BOTTOMRIGHT", true)
+    border("TOPLEFT",    "BOTTOMLEFT",  false)
+    border("TOPRIGHT",   "BOTTOMRIGHT", false)
 
     -- Item header (icon, quality border, name, tooltip)
     -- LootyMakeItemHeader returns the y cursor start (below the icon row)
@@ -235,8 +296,8 @@ function BuildMasterItemPanel(content, item, itemKey, yOffset, opts)
     -- Top padding is already embedded in LootyMakeItemHeader's starting Y.
     local totalH = -layout.y + LOOTY_PANEL_PADDING
     panel:SetHeight(totalH)
-    panel:SetPoint("TOPLEFT",  content, "TOPLEFT",  0, yOffset)
-    panel:SetPoint("TOPRIGHT", content, "TOPRIGHT", 0, yOffset)
+    panel:SetPoint("TOPLEFT",  panel:GetParent(), "TOPLEFT",  0, yOffset)
+    panel:SetPoint("TOPRIGHT", panel:GetParent(), "TOPRIGHT", 0, yOffset)
 
     return panel, totalH
 end
@@ -268,13 +329,18 @@ function RefreshMasterLootTab(content, frame)
         end
     end
 
+    -- Track which panels are currently needed
+    local activeKeys = {}
+
     -- ---- Active items ----
     local mlCount = 0
     if session then
         local activeItems = session:GetActiveItems()
         mlCount = #activeItems
         for _, item in ipairs(activeItems) do
-            local _, h = BuildMasterItemPanel(content, item, item.itemKey, yOffset, { isML = isML })
+            activeKeys[item.itemKey] = true
+            local panel = AcquirePanel(item.itemKey, content)
+            local _, h = BuildMasterItemPanel(panel, item, item.itemKey, yOffset, { isML = isML })
             yOffset = yOffset - h - 4
         end
     end
@@ -299,7 +365,9 @@ function RefreshMasterLootTab(content, frame)
             yOffset = yOffset - lblH
 
             for _, item in ipairs(doneItems) do
-                local _, h = BuildMasterItemPanel(content, item, item.itemKey, yOffset,
+                activeKeys[item.itemKey] = true
+                local panel = AcquirePanel(item.itemKey, content)
+                local _, h = BuildMasterItemPanel(panel, item, item.itemKey, yOffset,
                     { isDone = true, isML = isML })
                 yOffset = yOffset - h - 4
             end
@@ -307,7 +375,6 @@ function RefreshMasterLootTab(content, frame)
     end
 
     -- ---- Empty state ----
-    -- Only shown when there are truly no items at all (no active AND no done).
     local doneCount = session and #session:GetDoneItems() or 0
     if mlCount == 0 and doneCount == 0 then
         local emptyY = yOffset - 16
@@ -328,6 +395,9 @@ function RefreshMasterLootTab(content, frame)
         frame.tabs.master.text:SetText("Master: " .. mlCount)
     end
 
+    -- Release panels no longer in use
+    ReleaseUnused(activeKeys)
+
     return yOffset
 end
 
@@ -335,60 +405,29 @@ end
 -- ---- Timer update for Master Loot (called from UpdateTimers) ----
 -- ============================================================
 
-function UpdateMasterLootTimers(content)
-    local session = LootyMasterLoot:GetSession()
-    if not session then return end
-
-    for _, child in ipairs({ content:GetChildren() }) do
-        if child._mlItemKey and child._mlTimerBar and child._mlRollStart then
-            local elapsed   = GetTime() - child._mlRollStart
-            local duration  = child._mlDuration or LootyMasterLoot.rollDuration
+function UpdateMasterLootTimers()
+    for _, panel in pairs(panelPool) do
+        if panel:IsShown() and panel._mlItemKey and panel._mlTimerBar and panel._mlRollStart then
+            local elapsed   = GetTime() - panel._mlRollStart
+            local duration  = panel._mlDuration or LootyMasterLoot.rollDuration
             local remaining = math.max(0, duration - elapsed)
             local pct       = remaining / duration
-            local barW      = child:GetWidth() - LOOTY_PANEL_PADDING * 2
+            local barW      = panel:GetWidth() - LOOTY_PANEL_PADDING * 2
 
-            child._mlTimerBar:SetWidth(barW * pct)
-
-            if pct < 0.25 then
-                child._mlTimerBar:SetVertexColor(0.9, 0.2, 0.15, 0.8)
-            elseif pct < 0.5 then
-                child._mlTimerBar:SetVertexColor(0.9, 0.7, 0.1, 0.8)
-            else
-                child._mlTimerBar:SetVertexColor(0.4, 0.4, 0.4, 0.8)
-            end
-
-            if child._mlTimerText then
-                child._mlTimerText:SetText(string.format("%d:%02d",
-                    math.floor(remaining / 60), math.floor(remaining % 60)))
-            end
-        end
-    end
-end
-
--- ---- UpdateMasterLootTimer (called from MasterLoot timer callback) ----
-
-function LootyUpdateMasterLootTimer(itemKey, remaining)
-    if not LootyFrame or not LootyFrame.content then return end
-    for _, child in ipairs({ LootyFrame.content:GetChildren() }) do
-        if child._mlItemKey == itemKey and child._mlTimerBar and child._mlTimerBg then
-            local duration = child._mlDuration or LootyMasterLoot.rollDuration
-            local pct      = remaining / duration
-            local barW     = child:GetWidth() - LOOTY_PANEL_PADDING * 2
-            child._mlTimerBar:SetWidth(barW * pct)
+            panel._mlTimerBar:SetWidth(barW * pct)
 
             if pct < 0.25 then
-                child._mlTimerBar:SetVertexColor(0.9, 0.2, 0.15, 0.8)
+                panel._mlTimerBar:SetVertexColor(0.9, 0.2, 0.15, 0.8)
             elseif pct < 0.5 then
-                child._mlTimerBar:SetVertexColor(0.9, 0.7, 0.1, 0.8)
+                panel._mlTimerBar:SetVertexColor(0.9, 0.7, 0.1, 0.8)
             else
-                child._mlTimerBar:SetVertexColor(0.4, 0.4, 0.4, 0.8)
+                panel._mlTimerBar:SetVertexColor(0.4, 0.4, 0.4, 0.8)
             end
 
-            if child._mlTimerText then
-                child._mlTimerText:SetText(string.format("%d:%02d",
+            if panel._mlTimerText then
+                panel._mlTimerText:SetText(string.format("%d:%02d",
                     math.floor(remaining / 60), math.floor(remaining % 60)))
             end
-            break
         end
     end
 end

--- a/UI/OptionsUI.lua
+++ b/UI/OptionsUI.lua
@@ -30,6 +30,16 @@ function RefreshOptionsTab(content, frame)
     local isRaider = LootyMasterLoot and LootyMasterLoot:IsRaider()
     local syncOn   = Looty.db and Looty.db.syncBlizzardThreshold
 
+    -- Version label (top-right aligned)
+    local version = GetAddOnMetadata("Looty", "Version") or ""
+    if version ~= "" then
+        local verLbl = content:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+        verLbl:SetPoint("TOPRIGHT", content, "TOPRIGHT", -LOOTY_CONTENT_MARGIN, yOffset)
+        verLbl:SetText("Looty v" .. version)
+        verLbl:SetTextColor(0.4, 0.4, 0.4)
+        yOffset = yOffset - 18
+    end
+
     -- Section title
     local title, tH = LootyMakeLabel(content, "Master Loot Filters",
         0.7, 0.7, 0.7, yOffset)


### PR DESCRIPTION
UI:Refresh() hid children without removing them from the parent. Frames accumulated on the content frame until GetChildren() blew the Lua C stack after ~50+ rolls.

- Add frame pooling (AcquirePanel/ReleaseUnused) to GroupLootUI and MasterLootUI, keyed by rollID and itemKey respectively
- Timer update functions now iterate the pool instead of GetChildren()
- Remove redundant LootyUpdateMasterLootTimer callback (250ms global tick already covers all visible timers)
- Add version label to Options tab header
- Bump version to 2.1.1

Fixes #11