### PR TITLE
feat: award to winner button — GiveMasterLoot + trade state machine

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -52,7 +52,6 @@ function addon:PLAYER_LOGIN()
     self:RegisterEvent("PARTY_LOOT_METHOD_CHANGED")
     self:RegisterEvent("LOOT_OPENED")
     self:RegisterEvent("LOOT_CLOSED")
-    self:RegisterEvent("LOOT_SLOT_CLEARED")
     self:RegisterEvent("UPDATE_MASTER_LOOT_LIST")
     self:RegisterEvent("CHAT_MSG_SYSTEM")
     self:RegisterEvent("GET_ITEM_INFO_RECEIVED")
@@ -188,11 +187,6 @@ function addon:GET_ITEM_INFO_RECEIVED(event, itemID, success)
     if success then
         LootyMasterLoot:OnItemInfoReceived(itemID)
     end
-end
-
-function addon:LOOT_SLOT_CLEARED(event, slot)
-    if not self.db or not self.db.masterLootEnabled then return end
-    LootyMasterLoot:OnLootSlotCleared(slot)
 end
 
 function addon:UPDATE_MASTER_LOOT_LIST()

--- a/Core.lua
+++ b/Core.lua
@@ -52,8 +52,13 @@ function addon:PLAYER_LOGIN()
     self:RegisterEvent("PARTY_LOOT_METHOD_CHANGED")
     self:RegisterEvent("LOOT_OPENED")
     self:RegisterEvent("LOOT_CLOSED")
+    self:RegisterEvent("LOOT_SLOT_CLEARED")
+    self:RegisterEvent("UPDATE_MASTER_LOOT_LIST")
     self:RegisterEvent("CHAT_MSG_SYSTEM")
     self:RegisterEvent("GET_ITEM_INFO_RECEIVED")
+    -- Award / trade events
+    self:RegisterEvent("TRADE_SHOW")
+    self:RegisterEvent("TRADE_CLOSED")
 
     -- Addon messages (prefix-less in WoW 3.3.5 — RegisterAddonMessagePrefix
     -- was added in 4.1.0; in 3.3.5 CHAT_MSG_ADDON fires unconditionally).
@@ -183,6 +188,26 @@ function addon:GET_ITEM_INFO_RECEIVED(event, itemID, success)
     if success then
         LootyMasterLoot:OnItemInfoReceived(itemID)
     end
+end
+
+function addon:LOOT_SLOT_CLEARED(event, slot)
+    if not self.db or not self.db.masterLootEnabled then return end
+    LootyMasterLoot:OnLootSlotCleared(slot)
+end
+
+function addon:UPDATE_MASTER_LOOT_LIST()
+    if not self.db or not self.db.masterLootEnabled then return end
+    if LootyUI and LootyUI.Refresh then LootyUI:Refresh() end
+end
+
+function addon:TRADE_SHOW()
+    if not self.db or not self.db.masterLootEnabled then return end
+    LootyMasterLoot:OnTradeShow()
+end
+
+function addon:TRADE_CLOSED()
+    if not self.db or not self.db.masterLootEnabled then return end
+    LootyMasterLoot:OnTradeClosed()
 end
 
 -- ============================================================

--- a/MasterLoot.lua
+++ b/MasterLoot.lua
@@ -1046,6 +1046,24 @@ function MasterLoot:GetRaidRoster()
     return list
 end
 
+-- Finds the raid/party unitID for a player name (e.g. "raid5", "party2").
+-- Returns the unitID string, or nil if not found in the current group.
+-- This avoids requiring the ML to manually target the winner before trading.
+function MasterLoot:FindRaidUnit(playerName)
+    if GetNumRaidMembers() > 0 then
+        for i = 1, GetNumRaidMembers() do
+            local unit = "raid" .. i
+            if UnitName(unit) == playerName then return unit end
+        end
+    else
+        for i = 1, GetNumPartyMembers() do
+            local unit = "party" .. i
+            if UnitName(unit) == playerName then return unit end
+        end
+    end
+    return nil
+end
+
 -- Iterates GetMasterLootCandidate(1..40) and returns the index for playerName.
 function MasterLoot:FindCandidateIndex(playerName)
     for i = 1, 40 do
@@ -1110,25 +1128,26 @@ function MasterLoot:AwardToWinner(itemKey, playerName)
     local bag, slot = self:FindItemInBags(item.link)
     if not bag then return "ERR_ITEM_NOT_FOUND" end
 
-    -- The winner must be our current target. We'll keep trying via a retry
-    -- timer while the ML moves into trade range (common addon pattern).
-    if not UnitExists("target") or UnitName("target") ~= playerName then
-        return "ERR_TARGET_WINNER"
-    end
-    -- CheckInteractDistance type 2 = trade range
-    if not CheckInteractDistance("target", 2) then
+    -- Find the winner's raid/party unitID — no manual targeting required.
+    -- The ML can spam the button while walking toward the winner; once in
+    -- trade range InitiateTrade will succeed and TRADE_SHOW will fire.
+    local unit = self:FindRaidUnit(playerName)
+    if not unit then return "ERR_NOT_IN_GROUP" end
+    -- CheckInteractDistance type 2 = trade range (~10 yards)
+    if not CheckInteractDistance(unit, 2) then
         return "ERR_OUT_OF_RANGE"
     end
-    self:StartTradeSequence(playerName, bag, slot)
+    self:StartTradeSequence(playerName, unit, bag, slot)
     return nil
 end
 
 -- Initiates the trade and arms the state machine.
-function MasterLoot:StartTradeSequence(playerName, bag, slot)
+-- unit: raid/party unitID (e.g. "raid5") — no target required.
+function MasterLoot:StartTradeSequence(playerName, unit, bag, slot)
     self.tradeState = { winner = playerName, bag = bag, slot = slot }
-    InitiateTrade("target")
+    InitiateTrade(unit)
     if Looty.db and Looty.db.debug then
-        Looty:Print(string.format("[ML] InitiateTrade → %s (bag=%d slot=%d)", playerName, bag, slot))
+        Looty:Print(string.format("[ML] InitiateTrade(%s) → %s (bag=%d slot=%d)", unit, playerName, bag, slot))
     end
 end
 
@@ -1136,16 +1155,11 @@ end
 function MasterLoot:OnTradeShow()
     if not self.tradeState then return end
     local ts = self.tradeState
-    PickupContainerItem(ts.bag, ts.slot)
-    if CursorHasItem() then
-        DropItemOnUnit("target")
-        if Looty.db and Looty.db.debug then
-            Looty:Print("[ML] Item dropped into trade window for " .. ts.winner)
-        end
-    else
-        -- Item wasn't in that slot anymore (edge case)
-        self.tradeState = nil
-        Looty:Print("|cffff4040[Looty]|r Trade: item no longer in bags.")
+    -- UseContainerItem with the TradeFrame open moves the item directly into
+    -- the trade window — no cursor pickup or target required.
+    UseContainerItem(ts.bag, ts.slot)
+    if Looty.db and Looty.db.debug then
+        Looty:Print("[ML] UseContainerItem → trade window for " .. ts.winner)
     end
     -- ML accepts manually via Blizzard's trade UI — no AcceptTrade() call here.
 end

--- a/MasterLoot.lua
+++ b/MasterLoot.lua
@@ -265,6 +265,11 @@ MasterLoot.rollDuration = 30
 -- Roll timer frame (ML side)
 MasterLoot.rollTimer = nil
 
+-- Award override selection from dropdown: { [itemKey] = playerName }
+-- Set by the UI when the ML picks a non-winner from the dropdown.
+-- Cleared per-item when a new roll starts on that item.
+MasterLoot.pendingAward = {}
+
 -- Pending item info lookups (Raider side): { [itemID] = { [itemKey] = true } }
 MasterLoot.pendingItemInfo = {}
 
@@ -810,6 +815,9 @@ function MasterLoot:StartRoll(itemKey)
 
     if self.rollTimer then self.rollTimer:Hide() end
 
+    -- Clear any manual award override — a new roll resets the selection
+    if self.pendingAward then self.pendingAward[itemKey] = nil end
+
     item.rolling   = true
     item.rollStart = GetTime()
     item.rolls     = {}
@@ -1001,6 +1009,169 @@ end
 function MasterLoot:GetActiveItemCount()
     if not self.session then return 0 end
     return self.session:GetActiveItemCount()
+end
+
+-- ============================================================
+-- ---- Award to winner ----
+-- ============================================================
+
+-- Trade state machine (nil when idle):
+-- { winner=name, bag=n, slot=n, retryTimer=frame|nil }
+MasterLoot.tradeState = nil
+
+-- Returns a sorted list of current raid/party members: { {name, class}, ... }
+function MasterLoot:GetRaidRoster()
+    local list = {}
+    local myName = UnitName("player")
+    if GetNumRaidMembers() > 0 then
+        for i = 1, GetNumRaidMembers() do
+            local name, _, _, _, _, cls = GetRaidRosterInfo(i)
+            if name then
+                table.insert(list, { name = name, class = cls or "WARRIOR" })
+            end
+        end
+    else
+        -- party fallback
+        table.insert(list, { name = myName, class = select(2, UnitClass("player")) or "WARRIOR" })
+        for i = 1, GetNumPartyMembers() do
+            local unit = "party" .. i
+            local n = UnitName(unit)
+            if n then
+                local _, cls = UnitClass(unit)
+                table.insert(list, { name = n, class = cls or "WARRIOR" })
+            end
+        end
+    end
+    table.sort(list, function(a, b) return a.name < b.name end)
+    return list
+end
+
+-- Iterates GetMasterLootCandidate(1..40) and returns the index for playerName.
+function MasterLoot:FindCandidateIndex(playerName)
+    for i = 1, 40 do
+        local name = GetMasterLootCandidate(i)
+        if name == playerName then return i end
+    end
+    return nil
+end
+
+-- Searches bags 0..NUM_BAG_SLOTS for an item matching itemLink.
+-- Returns bag, slot or nil.
+function MasterLoot:FindItemInBags(itemLink)
+    if not itemLink or itemLink == "" then return nil end
+    for bag = 0, NUM_BAG_SLOTS do
+        for slot = 1, GetContainerNumSlots(bag) do
+            local link = GetContainerItemLink(bag, slot)
+            if link == itemLink then return bag, slot end
+        end
+    end
+    return nil
+end
+
+-- Single entry point for the Award button.
+-- Returns an error code string on failure, nil on success.
+function MasterLoot:AwardToWinner(itemKey, playerName)
+    if not self:IsML() then return "ERR_NOT_ML" end
+    local item = self.session and self.session:GetItem(itemKey)
+    if not item then return "ERR_NO_ITEM" end
+
+    -- ---- Scenario 1: loot window is open ----
+    if LootFrame and LootFrame:IsShown() then
+        -- Find which loot slot holds this item
+        local lootSlot
+        for i = 1, GetNumLootItems() do
+            if GetLootSlotLink(i) == item.link then
+                lootSlot = i
+                break
+            end
+        end
+        if not lootSlot then
+            -- Loot window open but this specific item is no longer in it
+            -- (already looted) — fall through to bag search
+            goto bags
+        end
+        local candidateIdx = self:FindCandidateIndex(playerName)
+        if not candidateIdx then return "ERR_NOT_CANDIDATE" end
+        GiveMasterLoot(lootSlot, candidateIdx)
+        -- LOOT_SLOT_CLEARED will fire → OnLootSlotCleared marks item done
+        if Looty.db and Looty.db.debug then
+            Looty:Print(string.format("[ML] GiveMasterLoot slot=%d candidate=%d (%s)",
+                lootSlot, candidateIdx, playerName))
+        end
+        return nil
+    end
+
+    -- ---- Scenario 2: item already in ML bags ----
+    ::bags::
+    local bag, slot = self:FindItemInBags(item.link)
+    if not bag then return "ERR_ITEM_NOT_FOUND" end
+
+    -- The winner must be our current target. We'll keep trying via a retry
+    -- timer while the ML moves into trade range (common addon pattern).
+    if not UnitExists("target") or UnitName("target") ~= playerName then
+        return "ERR_TARGET_WINNER"
+    end
+    -- CheckInteractDistance type 2 = trade range
+    if not CheckInteractDistance("target", 2) then
+        return "ERR_OUT_OF_RANGE"
+    end
+    self:StartTradeSequence(playerName, bag, slot)
+    return nil
+end
+
+-- Initiates the trade and arms the state machine.
+function MasterLoot:StartTradeSequence(playerName, bag, slot)
+    self.tradeState = { winner = playerName, bag = bag, slot = slot }
+    InitiateTrade("target")
+    if Looty.db and Looty.db.debug then
+        Looty:Print(string.format("[ML] InitiateTrade → %s (bag=%d slot=%d)", playerName, bag, slot))
+    end
+end
+
+-- Called by Core on TRADE_SHOW.
+function MasterLoot:OnTradeShow()
+    if not self.tradeState then return end
+    local ts = self.tradeState
+    PickupContainerItem(ts.bag, ts.slot)
+    if CursorHasItem() then
+        DropItemOnUnit("target")
+        if Looty.db and Looty.db.debug then
+            Looty:Print("[ML] Item dropped into trade window for " .. ts.winner)
+        end
+    else
+        -- Item wasn't in that slot anymore (edge case)
+        self.tradeState = nil
+        Looty:Print("|cffff4040[Looty]|r Trade: item no longer in bags.")
+    end
+    -- ML accepts manually via Blizzard's trade UI — no AcceptTrade() call here.
+end
+
+-- Called by Core on TRADE_CLOSED.
+function MasterLoot:OnTradeClosed()
+    if not self.tradeState then return end
+    if Looty.db and Looty.db.debug then
+        Looty:Print("[ML] Trade closed — cleaning up trade state.")
+    end
+    self.tradeState = nil
+    if LootyUI and LootyUI.Refresh then LootyUI:Refresh() end
+end
+
+-- Called by Core on LOOT_SLOT_CLEARED.
+-- Marks the corresponding item as done when the server confirms the award.
+function MasterLoot:OnLootSlotCleared(slot)
+    if not self.session then return end
+    -- Find the item whose slot index matches the cleared slot
+    for _, item in pairs(self.session.items) do
+        if item.slot == slot and not item:IsDone() then
+            item.isDone = true
+            self:SendMessage("ITEM_DONE" .. SEP .. item.itemKey)
+            if Looty.db and Looty.db.debug then
+                Looty:Print("[ML] LOOT_SLOT_CLEARED slot=" .. slot .. " → " .. item.name .. " marked done")
+            end
+            break
+        end
+    end
+    if LootyUI and LootyUI.Refresh then LootyUI:Refresh() end
 end
 
 -- ============================================================

--- a/MasterLoot.lua
+++ b/MasterLoot.lua
@@ -1076,8 +1076,9 @@ function MasterLoot:AwardToWinner(itemKey, playerName)
     if not item then return "ERR_NO_ITEM" end
 
     -- ---- Scenario 1: loot window is open ----
+    -- Only attempt direct award if the loot window is open AND the item is
+    -- still in a slot. If not found in the window, fall through to bag search.
     if LootFrame and LootFrame:IsShown() then
-        -- Find which loot slot holds this item
         local lootSlot
         for i = 1, GetNumLootItems() do
             if GetLootSlotLink(i) == item.link then
@@ -1085,24 +1086,21 @@ function MasterLoot:AwardToWinner(itemKey, playerName)
                 break
             end
         end
-        if not lootSlot then
-            -- Loot window open but this specific item is no longer in it
-            -- (already looted) — fall through to bag search
-            goto bags
+        if lootSlot then
+            local candidateIdx = self:FindCandidateIndex(playerName)
+            if not candidateIdx then return "ERR_NOT_CANDIDATE" end
+            GiveMasterLoot(lootSlot, candidateIdx)
+            -- LOOT_SLOT_CLEARED will fire → OnLootSlotCleared marks item done
+            if Looty.db and Looty.db.debug then
+                Looty:Print(string.format("[ML] GiveMasterLoot slot=%d candidate=%d (%s)",
+                    lootSlot, candidateIdx, playerName))
+            end
+            return nil
         end
-        local candidateIdx = self:FindCandidateIndex(playerName)
-        if not candidateIdx then return "ERR_NOT_CANDIDATE" end
-        GiveMasterLoot(lootSlot, candidateIdx)
-        -- LOOT_SLOT_CLEARED will fire → OnLootSlotCleared marks item done
-        if Looty.db and Looty.db.debug then
-            Looty:Print(string.format("[ML] GiveMasterLoot slot=%d candidate=%d (%s)",
-                lootSlot, candidateIdx, playerName))
-        end
-        return nil
+        -- Item not in loot window (already looted) — fall through to bag search
     end
 
     -- ---- Scenario 2: item already in ML bags ----
-    ::bags::
     local bag, slot = self:FindItemInBags(item.link)
     if not bag then return "ERR_ITEM_NOT_FOUND" end
 

--- a/MasterLoot.lua
+++ b/MasterLoot.lua
@@ -1090,11 +1090,17 @@ function MasterLoot:AwardToWinner(itemKey, playerName)
             local candidateIdx = self:FindCandidateIndex(playerName)
             if not candidateIdx then return "ERR_NOT_CANDIDATE" end
             GiveMasterLoot(lootSlot, candidateIdx)
-            -- LOOT_SLOT_CLEARED will fire → OnLootSlotCleared marks item done
+            -- Mark done immediately — we called GiveMasterLoot so we know it
+            -- went to the winner. LOOT_SLOT_CLEARED is NOT used for this because
+            -- it also fires when the ML takes an item into their own bags.
+            item.isDone = true
+            item.winner = playerName
+            self:SendMessage("ITEM_DONE" .. SEP .. item.itemKey)
             if Looty.db and Looty.db.debug then
-                Looty:Print(string.format("[ML] GiveMasterLoot slot=%d candidate=%d (%s)",
+                Looty:Print(string.format("[ML] GiveMasterLoot slot=%d candidate=%d (%s) → done",
                     lootSlot, candidateIdx, playerName))
             end
+            if LootyUI and LootyUI.Refresh then LootyUI:Refresh() end
             return nil
         end
         -- Item not in loot window (already looted) — fall through to bag search
@@ -1154,23 +1160,11 @@ function MasterLoot:OnTradeClosed()
     if LootyUI and LootyUI.Refresh then LootyUI:Refresh() end
 end
 
--- Called by Core on LOOT_SLOT_CLEARED.
--- Marks the corresponding item as done when the server confirms the award.
-function MasterLoot:OnLootSlotCleared(slot)
-    if not self.session then return end
-    -- Find the item whose slot index matches the cleared slot
-    for _, item in pairs(self.session.items) do
-        if item.slot == slot and not item:IsDone() then
-            item.isDone = true
-            self:SendMessage("ITEM_DONE" .. SEP .. item.itemKey)
-            if Looty.db and Looty.db.debug then
-                Looty:Print("[ML] LOOT_SLOT_CLEARED slot=" .. slot .. " → " .. item.name .. " marked done")
-            end
-            break
-        end
-    end
-    if LootyUI and LootyUI.Refresh then LootyUI:Refresh() end
-end
+-- OnLootSlotCleared intentionally NOT implemented.
+-- LOOT_SLOT_CLEARED fires for both GiveMasterLoot AND the ML taking items into
+-- their own bags — there is no way to distinguish the two from the event alone.
+-- isDone is set explicitly in AwardToWinner right after GiveMasterLoot succeeds,
+-- and via ToggleDone when the ML manually marks an item as delivered.
 
 -- ============================================================
 -- ---- Test data injection ----

--- a/UI/MasterLootUI.lua
+++ b/UI/MasterLootUI.lua
@@ -57,15 +57,18 @@ end
 -- ---- Determine what action buttons a player can take ----
 -- ============================================================
 -- Returns one of:
---   ML:    "ml_idle" | "ml_rolling" | "ml_tie"
+--   ML:    "ml_idle" | "ml_idle_reroll" | "ml_winner" | "ml_rolling" | "ml_tie"
 --   Raider: "raider_roll" | "raider_rolled" | "raider_reroll" | "raider_rerolled"
 --           "raider_not_eligible" | "raider_tie_pending" | nil
 
 local function GetItemAction(item, isML)
     if item:IsDone() then return nil end
     if isML then
-        if item:IsTied() then return "ml_tie" end
-        return item:IsRolling() and "ml_rolling" or "ml_idle"
+        if item:IsRolling() then return "ml_rolling" end
+        if item:IsTied()    then return "ml_tie" end
+        if item.winner      then return "ml_winner" end
+        if item.wasRolled   then return "ml_idle_reroll" end
+        return "ml_idle"
     else
         local myName = UnitName("player")
         -- Re-roll phase: eligiblePlayers is set and rolling
@@ -146,6 +149,69 @@ local function RenderTimerBar(panel, layout, item)
     LootyMakeTimerBar(panel, layout, LootyMasterLoot.rollDuration, item.rollStart, "_ml", item.itemKey)
 end
 
+-- Build the award button + dropdown arrow for award states.
+-- awardLabel: text for the main button (e.g. "Award: WarriorK" or "Award to...")
+-- winnerName: pre-selected name (nil = no pre-selection)
+-- Returns: awardBtn (the wide label part), height consumed by the award row.
+local function RenderAwardRow(panel, layout, item, awardLabel, winnerName)
+    local BTN_H   = 20
+    local TOP_GAP = 4
+    local pp      = LOOTY_PANEL_PADDING
+    local atY     = layout.y - TOP_GAP
+    local panelW  = panel:GetWidth()
+    local arrowW  = 24   -- width of the ▼ arrow button
+    local mainW   = panelW - pp * 2 - arrowW - 2  -- 2px gap between main+arrow
+
+    -- Color: blue-ish when winner known, muted grey when no winner yet
+    local hasWinner = winnerName ~= nil
+    local NC = hasWinner and { 0.08, 0.20, 0.38 } or { 0.18, 0.18, 0.18 }
+    local HC = hasWinner and { 0.14, 0.32, 0.55 } or { 0.26, 0.26, 0.26 }
+    local TC = hasWinner and { 0.50, 0.80, 1.00 } or { 0.65, 0.65, 0.65 }
+
+    -- Main award button (wide)
+    local mainBtn = LootyMakeButton(panel, awardLabel, mainW, BTN_H, NC, HC, TC,
+        function()
+            if not winnerName then return end  -- need a selection first
+            local err = LootyMasterLoot:AwardToWinner(item.itemKey, winnerName)
+            if err then
+                local msgs = {
+                    ERR_NOT_ML         = "You are not the Master Looter.",
+                    ERR_NO_ITEM        = "Item not found in session.",
+                    ERR_NOT_CANDIDATE  = "Player is not a loot candidate.",
+                    ERR_ITEM_NOT_FOUND = "Item not found in loot window or bags.",
+                    ERR_TARGET_WINNER  = "Target " .. (winnerName or "?") .. " first.",
+                    ERR_OUT_OF_RANGE   = "Move closer to " .. (winnerName or "?") .. ".",
+                }
+                Looty:Print("|cffff6040[Award]|r " .. (msgs[err] or err))
+            end
+        end)
+    mainBtn:SetPoint("TOPLEFT", panel, "TOPLEFT", pp, atY)
+    mainBtn:Show()
+
+    -- Arrow button (▼) opens the roster dropdown
+    local BTN_ARROW_NC = { 0.10, 0.10, 0.10 }
+    local BTN_ARROW_HC = { 0.22, 0.22, 0.22 }
+    local BTN_ARROW_TC = { 0.70, 0.70, 0.70 }
+    local arrowBtn = LootyMakeButton(panel, "v", arrowW, BTN_H,
+        BTN_ARROW_NC, BTN_ARROW_HC, BTN_ARROW_TC, nil)
+    arrowBtn:SetPoint("LEFT", mainBtn, "RIGHT", 2, 0)
+    arrowBtn:Show()
+
+    -- Dropdown: built fresh on each click so the roster is always up to date
+    arrowBtn:SetScript("OnClick", function()
+        local entries = LootyMasterLoot:GetRaidRoster()
+        LootyToggleDropdown(arrowBtn, entries, function(selectedName)
+            -- Re-render the whole panel so the button label + callback update
+            LootyMasterLoot.pendingAward = LootyMasterLoot.pendingAward or {}
+            LootyMasterLoot.pendingAward[item.itemKey] = selectedName
+            if LootyUI and LootyUI.Refresh then LootyUI:Refresh() end
+        end)
+    end)
+
+    layout:Advance(TOP_GAP + BTN_H + 4)
+    return mainBtn
+end
+
 local function RenderActionButtons(panel, layout, item, action)
     if not action then return end
 
@@ -154,6 +220,8 @@ local function RenderActionButtons(panel, layout, item, action)
     local BOT_GAP = 4
     local row     = LootyHLayout(4)
     local atY     = layout.y - TOP_GAP
+    -- selfManaged: states that call layout:Advance themselves skip the one at the end
+    local selfManaged = false
 
     if action == "ml_idle" then
         local startBtn = LootyMakeButton(panel, "Start Roll", 70, BTN_H,
@@ -165,6 +233,47 @@ local function RenderActionButtons(panel, layout, item, action)
         row:Place(startBtn, panel, LOOTY_PANEL_PADDING, atY)
         row:Place(doneBtn,  panel, LOOTY_PANEL_PADDING, atY)
         startBtn:Show(); doneBtn:Show()
+
+    elseif action == "ml_idle_reroll" then
+        selfManaged = true
+        -- Roll happened before but no winner yet — show Award dropdown + Re-Roll + Done
+        local pending = LootyMasterLoot.pendingAward and LootyMasterLoot.pendingAward[item.itemKey]
+        local awardLabel = pending and ("Award: " .. pending) or "Award to..."
+        RenderAwardRow(panel, layout, item, awardLabel, pending)
+
+        atY = layout.y - TOP_GAP
+        row = LootyHLayout(4)
+        local rerollBtn = LootyMakeButton(panel, "Re-Roll", 65, BTN_H,
+            BTN_GREEN[1], BTN_GREEN[2], BTN_GREEN[3],
+            function() LootyMasterLoot:StartRoll(item.itemKey) end)
+        local doneBtn = LootyMakeButton(panel, "Done", 55, BTN_H,
+            BTN_RED[1], BTN_RED[2], BTN_RED[3],
+            function() LootyMasterLoot:ToggleDone(item.itemKey) end)
+        row:Place(rerollBtn, panel, LOOTY_PANEL_PADDING, atY)
+        row:Place(doneBtn,   panel, LOOTY_PANEL_PADDING, atY)
+        rerollBtn:Show(); doneBtn:Show()
+        layout:Advance(TOP_GAP + BTN_H + BOT_GAP)
+
+    elseif action == "ml_winner" then
+        selfManaged = true
+        -- Winner determined — award button pre-filled, override dropdown still available
+        local pending = LootyMasterLoot.pendingAward and LootyMasterLoot.pendingAward[item.itemKey]
+        local target  = pending or item.winner
+        local awardLabel = "Award: " .. (target or "?")
+        RenderAwardRow(panel, layout, item, awardLabel, target)
+
+        atY = layout.y - TOP_GAP
+        row = LootyHLayout(4)
+        local rerollBtn = LootyMakeButton(panel, "Re-Roll", 65, BTN_H,
+            BTN_GREEN[1], BTN_GREEN[2], BTN_GREEN[3],
+            function() LootyMasterLoot:StartRoll(item.itemKey) end)
+        local doneBtn = LootyMakeButton(panel, "Done", 55, BTN_H,
+            BTN_RED[1], BTN_RED[2], BTN_RED[3],
+            function() LootyMasterLoot:ToggleDone(item.itemKey) end)
+        row:Place(rerollBtn, panel, LOOTY_PANEL_PADDING, atY)
+        row:Place(doneBtn,   panel, LOOTY_PANEL_PADDING, atY)
+        rerollBtn:Show(); doneBtn:Show()
+        layout:Advance(TOP_GAP + BTN_H + BOT_GAP)
 
     elseif action == "ml_tie" then
         local rerollBtn = LootyMakeButton(panel, "Re-roll", 65, BTN_H,
@@ -221,7 +330,9 @@ local function RenderActionButtons(panel, layout, item, action)
         -- No button — status line already explains the state
     end
 
-    layout:Advance(TOP_GAP + BTN_H + BOT_GAP)
+    if not selfManaged then
+        layout:Advance(TOP_GAP + BTN_H + BOT_GAP)
+    end
 end
 
 local function RenderRollList(panel, layout, item, alpha)

--- a/UI/MasterLootUI.lua
+++ b/UI/MasterLootUI.lua
@@ -179,7 +179,7 @@ local function RenderAwardRow(panel, layout, item, awardLabel, winnerName)
                     ERR_NO_ITEM        = "Item not found in session.",
                     ERR_NOT_CANDIDATE  = "Player is not a loot candidate.",
                     ERR_ITEM_NOT_FOUND = "Item not found in loot window or bags.",
-                    ERR_TARGET_WINNER  = "Target " .. (winnerName or "?") .. " first.",
+                    ERR_NOT_IN_GROUP   = (winnerName or "?") .. " is not in your group.",
                     ERR_OUT_OF_RANGE   = "Move closer to " .. (winnerName or "?") .. ".",
                 }
                 Looty:Print("|cffff6040[Award]|r " .. (msgs[err] or err))

--- a/UI/Primitives.lua
+++ b/UI/Primitives.lua
@@ -499,7 +499,176 @@ function LootyMakeEmptyState(parent, text, yOffset)
     return 24
 end
 
--- Item header: icon + quality border + name fontstring + tooltip.
+-- ============================================================
+-- ---- Custom dropdown ----
+-- ============================================================
+-- LootyMakeDropdown — themed dropdown list anchored below an anchor frame.
+--
+-- anchor  — frame to anchor below (BOTTOM of anchor = TOP of dropdown)
+-- entries — array of { name=string, class=string } (class optional)
+-- onSelect — function(name) called when a row is clicked
+--
+-- Returns the dropdown frame (hidden by default).
+-- Call :Show() / :Hide() to toggle, or use LootyToggleDropdown().
+--
+-- Implementation notes:
+--   • Floats on UIParent so it always renders on top.
+--   • Closes itself when the player clicks anywhere outside.
+--   • Each row: 14×14 class icon + player name, hover highlight.
+--   • Max visible rows before scrolling: 12 (keeps it usable in raids).
+
+local DROPDOWN_ROW_H   = 18
+local DROPDOWN_MAX_VIS = 12
+local DROPDOWN_WIDTH   = 160
+local DROPDOWN_PAD     = 6
+
+-- Active dropdown reference — only one open at a time.
+local _activeDropdown = nil
+
+-- Close the currently open dropdown (if any).
+local function CloseActiveDropdown()
+    if _activeDropdown and _activeDropdown:IsShown() then
+        _activeDropdown:Hide()
+    end
+    _activeDropdown = nil
+end
+
+-- Global click-outside detector (created once, reused).
+local _clickCatcher
+local function EnsureClickCatcher()
+    if _clickCatcher then return end
+    _clickCatcher = CreateFrame("Frame", "LootyDropdownClickCatcher", UIParent)
+    _clickCatcher:SetAllPoints(UIParent)
+    _clickCatcher:SetFrameLevel(99)
+    _clickCatcher:EnableMouse(true)
+    _clickCatcher:Hide()
+    _clickCatcher:SetScript("OnMouseDown", function()
+        CloseActiveDropdown()
+        _clickCatcher:Hide()
+    end)
+end
+
+function LootyMakeDropdown(anchor, entries, onSelect)
+    EnsureClickCatcher()
+
+    local rowCount = math.min(#entries, DROPDOWN_MAX_VIS)
+    local totalH   = rowCount * DROPDOWN_ROW_H + DROPDOWN_PAD * 2
+
+    -- Floating frame on UIParent, above everything
+    local dd = CreateFrame("Frame", nil, UIParent)
+    dd:SetSize(DROPDOWN_WIDTH, totalH)
+    dd:SetFrameLevel(101)
+    dd:Hide()
+
+    -- Background
+    local bg = LootyColorTex(dd, "BACKGROUND", 0.08, 0.08, 0.08, 0.97)
+    bg:SetAllPoints(dd)
+
+    -- Border (4 sides, same as LootyMakePanel)
+    local function border(pt1, pt2, isH)
+        local t = LootyColorTex(dd, "BORDER", 0.30, 0.30, 0.30, 0.7)
+        t:SetPoint(pt1, dd, pt1, 0, 0)
+        t:SetPoint(pt2, dd, pt2, 0, 0)
+        if isH then t:SetHeight(1) else t:SetWidth(1) end
+    end
+    border("TOPLEFT",    "TOPRIGHT",    true)
+    border("BOTTOMLEFT", "BOTTOMRIGHT", true)
+    border("TOPLEFT",    "BOTTOMLEFT",  false)
+    border("TOPRIGHT",   "BOTTOMRIGHT", false)
+
+    -- Position: anchored below the anchor frame, left-aligned
+    dd:SetPoint("TOPLEFT", anchor, "BOTTOMLEFT", 0, -2)
+
+    -- Rows
+    for i, entry in ipairs(entries) do
+        if i > DROPDOWN_MAX_VIS then break end
+        local yOff = -DROPDOWN_PAD - (i - 1) * DROPDOWN_ROW_H
+
+        local row = CreateFrame("Button", nil, dd)
+        row:SetSize(DROPDOWN_WIDTH - 2, DROPDOWN_ROW_H)
+        row:SetPoint("TOPLEFT", dd, "TOPLEFT", 1, yOff)
+        row:EnableMouse(true)
+
+        -- Hover background (hidden by default)
+        local hoverBg = LootyColorTex(row, "HIGHLIGHT", 0.25, 0.25, 0.40, 0.5)
+        hoverBg:SetAllPoints(row)
+        hoverBg:Hide()
+
+        -- Class icon
+        local cIcon = row:CreateTexture(nil, "ARTWORK")
+        cIcon:SetSize(14, 14)
+        cIcon:SetPoint("LEFT", row, "LEFT", DROPDOWN_PAD, 0)
+        if entry.class then
+            LootyApplyClassIcon(cIcon, entry.name)
+        else
+            cIcon:SetTexture("Interface\\Icons\\INV_Misc_QuestionMark")
+        end
+
+        -- Name label
+        local lbl = row:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+        lbl:SetPoint("LEFT",  cIcon, "RIGHT", 4, 0)
+        lbl:SetPoint("RIGHT", row,   "RIGHT", -DROPDOWN_PAD, 0)
+        lbl:SetJustifyH("LEFT")
+        lbl:SetText(entry.name)
+        lbl:SetTextColor(0.90, 0.90, 0.90)
+
+        row:SetScript("OnEnter", function()
+            hoverBg:Show()
+            lbl:SetTextColor(1, 1, 1)
+        end)
+        row:SetScript("OnLeave", function()
+            hoverBg:Hide()
+            lbl:SetTextColor(0.90, 0.90, 0.90)
+        end)
+        row:SetScript("OnClick", function()
+            CloseActiveDropdown()
+            _clickCatcher:Hide()
+            onSelect(entry.name)
+        end)
+    end
+
+    -- Public helpers
+    function dd:Open()
+        CloseActiveDropdown()
+        -- Re-anchor in case the panel scrolled
+        self:ClearAllPoints()
+        self:SetPoint("TOPLEFT", anchor, "BOTTOMLEFT", 0, -2)
+        -- Make sure it doesn't go off-screen below
+        local absBottom = self:GetBottom()
+        if absBottom and absBottom < 0 then
+            self:ClearAllPoints()
+            self:SetPoint("BOTTOMLEFT", anchor, "TOPLEFT", 0, 2)
+        end
+        _activeDropdown = self
+        _clickCatcher:SetFrameLevel(self:GetFrameLevel() - 1)
+        _clickCatcher:Show()
+        self:Show()
+    end
+
+    function dd:Close()
+        CloseActiveDropdown()
+        _clickCatcher:Hide()
+    end
+
+    return dd
+end
+
+-- Convenience: rebuild and open a dropdown each click (entries can change between clicks).
+-- Returns the created dropdown so callers can hold a reference if needed.
+function LootyToggleDropdown(anchor, entries, onSelect)
+    -- If the same anchor's dropdown is already open, close it
+    if _activeDropdown and _activeDropdown:IsShown() then
+        CloseActiveDropdown()
+        _clickCatcher:Hide()
+        return
+    end
+    local dd = LootyMakeDropdown(anchor, entries, onSelect)
+    dd:Open()
+    return dd
+end
+
+-- ============================================================
+-- ---- Item header: icon + quality border + name fontstring + tooltip.
 -- Anchors icon TOPLEFT inside parent at (PANEL_PADDING, -PANEL_PADDING).
 -- Returns yOffset after the header (i.e. the next usable yOffset below the icon).
 function LootyMakeItemHeader(parent, item, iconH, alpha)


### PR DESCRIPTION
Closes #9

## Summary
- Adds an **Award** button to each item panel (ML only) once a winner exists or a roll has happened
- Handles two scenarios automatically: direct `GiveMasterLoot` from the loot window, and trade sequence when items are in ML bags
- Custom themed dropdown lets ML override the recipient (full raid roster, consistent with addon style)

## How it works

**Scenario 1 — Loot window open:**
Finds the item slot via `GetLootSlotLink`, finds the candidate index via `GetMasterLootCandidate(1..40)`, calls `GiveMasterLoot(slot, idx)` directly.

**Scenario 2 — Item in ML bags:**
`FindRaidUnit()` iterates `raid1..raid40` to resolve the winner's unitID — no manual target needed. `InitiateTrade(unitID)` opens the trade, then `UseContainerItem(bag, slot)` places the item directly into the trade window (documented TradeFrame exception). ML confirms manually.

## Changes

| File | Change |
|------|--------|
| `MasterLoot.lua` | `AwardToWinner`, `FindCandidateIndex`, `FindRaidUnit`, `FindItemInBags`, `StartTradeSequence`, `OnTradeShow`, `OnTradeClosed`, `GetRaidRoster`, `pendingAward` table |
| `Core.lua` | Register `UPDATE_MASTER_LOOT_LIST`, `TRADE_SHOW`, `TRADE_CLOSED` + handlers |
| `UI/MasterLootUI.lua` | `ml_winner` + `ml_idle_reroll` states, `RenderAwardRow`, dropdown integration |
| `UI/Primitives.lua` | `LootyMakeDropdown` + `LootyToggleDropdown` — themed floating dropdown |

## Fixes included
- `goto` replaced with nested `if` (Lua 5.1 compatibility — WoW 3.3.5)
- `LOOT_SLOT_CLEARED` removed — it fires on ML self-loot too, cannot distinguish from `GiveMasterLoot`
- `DropItemOnUnit("target")` replaced with `UseContainerItem` — works without target
- `TargetByName` not available in 3.3.5; unitID iteration used instead